### PR TITLE
Chore: enforce node >= 20 <21

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typescript": "5.4.2"
   },
   "engines": {
-    "node": "^18 || ^20",
+    "node": ">=20 <21",
     "pnpm": ">=9.8.0 <10.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
What the title says, i think we should all be aligned on Node >= 20, Node 22 will be the new long term support (LTS) version from next month october, also Node 18 has been in maintenance since last year.

![image](https://github.com/user-attachments/assets/d8c584c7-b8c7-4835-b252-68a6543c3398)

https://nodejs.org/en/about/previous-releases