### PR TITLE
Chore: move latticexyz under devdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@commitlint/config-conventional": "19.2.2",
     "@latticexyz/cli": "2.2.2",
     "@latticexyz/common": "2.2.2",
+    "@latticexyz/explorer": "^2.2.2",
+    "@latticexyz/store-indexer": "2.2.2",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",
@@ -28,9 +30,5 @@
   "engines": {
     "node": "^18 || ^20",
     "pnpm": ">=9.8.0 <10.0.0"
-  },
-  "dependencies": {
-    "@latticexyz/explorer": "^2.2.2",
-    "@latticexyz/store-indexer": "2.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@latticexyz/explorer':
-        specifier: ^2.2.2
-        version: 2.2.2(@aws-sdk/client-kms@3.635.0)(@opentelemetry/api@1.9.0)(@tanstack/query-core@5.54.1)(@types/react-dom@18.2.7)(@types/react@18.2.22)(asn1.js@5.4.1)(postcss@8.4.41)(typescript@5.4.2)
-      '@latticexyz/store-indexer':
-        specifier: 2.2.2
-        version: 2.2.2(@aws-sdk/client-kms@3.635.0)(@opentelemetry/api@1.9.0)(@types/react@18.2.22)(asn1.js@5.4.1)(kysely@0.26.3)(react@18.3.1)(sql.js@1.11.0)(typescript@5.4.2)
     devDependencies:
       '@commitlint/cli':
         specifier: 19.4.0
@@ -27,6 +20,12 @@ importers:
       '@latticexyz/common':
         specifier: 2.2.2
         version: 2.2.2(@aws-sdk/client-kms@3.635.0)(asn1.js@5.4.1)(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+      '@latticexyz/explorer':
+        specifier: ^2.2.2
+        version: 2.2.2(@aws-sdk/client-kms@3.635.0)(@opentelemetry/api@1.9.0)(@tanstack/query-core@5.54.1)(@types/react-dom@18.2.7)(@types/react@18.2.22)(asn1.js@5.4.1)(postcss@8.4.41)(typescript@5.4.2)
+      '@latticexyz/store-indexer':
+        specifier: 2.2.2
+        version: 2.2.2(@aws-sdk/client-kms@3.635.0)(@opentelemetry/api@1.9.0)(@types/react@18.2.22)(asn1.js@5.4.1)(kysely@0.26.3)(react@18.3.1)(sql.js@1.11.0)(typescript@5.4.2)
       '@types/debug':
         specifier: 4.1.7
         version: 4.1.7


### PR DESCRIPTION
What the title says ☝️  
1. Since these are only used under dev and we don't ship them the should also be added to `devDependencies`.
2. We introduced `^` for `@latticexyz/explorer`, may lead to others installing newer versions these dependencies should always have same version.

The reactive-native peer deps issue, is something that needs to be fixed in the `@metamask/sdk` package outside of our scope, since we will never use this they should have added it as an optional peer dep 👇 
<img width="467" alt="Screenshot 2024-09-08 at 16 25 31" src="https://github.com/user-attachments/assets/df98a91f-3c8c-4c9c-b4d8-0be0a801165d">
