### PR TITLE
Tune TSConfig and add some docs

### DIFF
--- a/packages/client/docs/TypeScript.md
+++ b/packages/client/docs/TypeScript.md
@@ -1,0 +1,48 @@
+# TypeScript
+
+This page is about how our TypeScript is configured in our client code.
+
+## TSConfig
+
+Our TypeScript configuration extends the root `tsconfig.json`, which in turn extends the config `@latticexyz/common/tsconfig.base.json`
+
+### Compiler Options:
+
+- [`types = [...]`](https://www.typescriptlang.org/tsconfig#types); specifies the types we want to include without being referenced in a source file.
+- [`target = "ESNext"`](https://www.typescriptlang.org/tsconfig#target); is set to `ESNext` and its up to the tools such like [esbuild](https://github.com/evanw/esbuild) and/or [rollup](https://rollupjs.org) to transpile and generate the correct code for the given client browser(s) target platform.
+- [`lib = ["ESNext", "DOM", "DOM.iterable"]`](https://www.typescriptlang.org/tsconfig#lib); tells TypeScript to include the type definitions for [`ESNext`](https://github.com/microsoft/TypeScript/blob/main/lib/lib.esnext.d.ts), [`DOM`](https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts) and [`DOM.Iterable`](https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.iterable.d.ts).
+- [`module = "ESNext"`](https://www.typescriptlang.org/tsconfig#module); tells TypeScript to set the [module](https://www.typescriptlang.org/docs/handbook/modules.html) system for the program to `ESNext`.
+- [`esModuleInterop = true`](https://www.typescriptlang.org/tsconfig#esModuleInterop); is enabled and ensures interop with CommonJS/AMD/UMD modules. This also enables the [`allowSyntheticDefaultImports`](https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports) option.
+- [`strict = true`](https://www.typescriptlang.org/tsconfig#strict); is enabled and ensures a wide range of type checking behavior that results in stronger guarantees of program correctness.
+- [`strictPropertyInitialization = false`](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization); is disabled so that we get no error on properties that are declared but not set in constructor (will enable it in upcoming code, enabled by default by strict mode).
+- [`useDefineForClassFields = false`](https://www.typescriptlang.org/tsconfig#useDefineForClassFields); is disabled so we are not actually emitting standard ECMA compliant class field (we will enable it in upcoming code)
+- [`jsx = "react-jsx"`](https://www.typescriptlang.org/tsconfig#jsx); specifies that react-jsx code is generated.
+- [`paths = ["@package-name": ["location"], …`](https://www.typescriptlang.org/tsconfig#jsx); Specifies a set of entries that re-map imports to additional lookup locations.
+
+
+#### Inherited from `@latticexyz/common/tsconfig.base.json`
+
+- [`noEmit = true`](https://www.typescriptlang.org/tsconfig#noEmit); disables generating js files from ts files under compilation.
+- [`declaration = true`](https://www.typescriptlang.org/tsconfig#declaration); Emits declaration `d.ts` files when emit is enabled, or emit declaration only flag is used (not relevant)
+- [`noErrorTruncation = true`](https://www.typescriptlang.org/tsconfig#noErrorTruncation); Disable truncating types in error messages.
+- [`resolveJsonModule = true`](https://www.typescriptlang.org/tsconfig#resolveJsonModule); Enabled importing JSON files.
+- [`forceConsistentCasingInFileNames = true`](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames); Ensures that casing is correct in imports.
+- [`sourceMap = true`](https://www.typescriptlang.org/tsconfig#resolveJsonModule); Creates sourceMap for emmited JS files.
+
+#### Strict mode
+
+Strict mode is enabled and it therefore also enables the following options:
+
+- [`alwaysStrict = true`](https://www.typescriptlang.org/tsconfig#alwaysStrict); is enabled and ensures that our files are parsed in the ECMAScript strict mode, and emit `"use strict"` for each source file.
+- [`strictNullChecks = true`](https://www.typescriptlang.org/tsconfig#strictNullChecks); is enabled making `null` and `undefined` have their own distinct types and we will get a type error if we try to use them where a concrete value is expected.
+- [`strictBindCallApply = true`](https://www.typescriptlang.org/tsconfig#strictBindCallApply); is enabled and TypeScript will check that the built-in methods of functions `call`, `bind`, and `apply` are invoked with correct argument for the underlying function:
+- [`strictFunctionTypes = true`](https://www.typescriptlang.org/tsconfig#strictFunctionTypes); is enabled and ensures functions parameters to be checked more correctly.
+- [`strictPropertyInitialization = true`](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization); is enabled and TypeScript will raise an error when a class property was declared but not set in the constructor when it has no default initializer value.
+- [`noImplicitAny = true`](https://www.typescriptlang.org/tsconfig#noImplicitAny); is enabled and TypeScript will raise an error when it cannot infer the type of a variable.
+- [`noImplicitThis = true`](https://www.typescriptlang.org/tsconfig#noImplicitThis); is enabled and TypeScript will raise an error on `this` expressions with an implied `any` type.
+
+#### Target ESNext
+
+Target is ESNext and it therefore also enables the following options:
+
+- [`useDefineForClassFields = true`](https://www.typescriptlang.org/tsconfig#useDefineForClassFields); is enabled and is used as part of migrating to the upcoming standard version of class fields. (Currently disabled however will be enabled in upcoming code changes)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,7 +9,9 @@
     "dev": "wait-port localhost:8545 && vite",
     "format": "prettier --write .",
     "preview": "vite preview",
-    "test": "tsc --noEmit"
+    "test": "echo 'tests not implemented'",
+    "lint": "pnpm lint:typecheck",
+    "lint:typecheck": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {
     "@latticexyz/block-logs-stream": "2.2.2",

--- a/packages/client/src/Frontend/Components/RemoteModal.tsx
+++ b/packages/client/src/Frontend/Components/RemoteModal.tsx
@@ -1,6 +1,7 @@
 import { ModalId } from "@df/types";
 import * as React from "react";
 import ReactDOM from "react-dom";
+// @ts-expect-error We need to add ModalPane code
 import { ModalPane } from "../Views/ModalPane";
 
 /**

--- a/packages/client/src/hooks/useBalance.ts
+++ b/packages/client/src/hooks/useBalance.ts
@@ -7,7 +7,7 @@ import {
   MINIMUM_BALANCE,
   RECOMMENDED_BALANCE,
   zeroAddress,
-} from "@wallet/Utils";
+} from "@wallet/utils";
 
 // You can define a threshold constant for low balance
 

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -99,6 +99,7 @@ export function createSystemCalls(
     try {
       // Call the createPlanet function on the contract
       const tx = await worldContract.write.df__createPlanet([
+        // @ts-expect-error will be fixed in 9stx6/main-Iworld merge
         planetHash,
         owner as `0x${string}`,
         perlin,
@@ -131,6 +132,7 @@ export function createSystemCalls(
     try {
       // Call the move function on the contract
       const tx = await worldContract.write.df__move({
+        // @ts-expect-error needs to be fixed wrong type
         proof,
         moveInput,
         population,

--- a/packages/client/src/wallet/WalletButton.tsx
+++ b/packages/client/src/wallet/WalletButton.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { CustomConnectButton } from "@wallet/CustomConnectButton";
 import { useAccount, useDisconnect, useWalletClient } from "wagmi";
-import { formatAddress } from "./Utils";
+import { formatAddress } from "./utils";
 import { getNetworkConfig } from "@mud/getNetworkConfig";
 import { WalletPane } from "./WalletPane";
 import { useMUD } from "@mud/MUDContext";

--- a/packages/client/src/wallet/WalletPane.tsx
+++ b/packages/client/src/wallet/WalletPane.tsx
@@ -5,7 +5,7 @@ import {
   RECOMMENDED_BALANCE,
   LOW_BALANCE_THRESHOLD,
   zeroAddress,
-} from "@wallet/Utils";
+} from "@wallet/utils";
 import { formatEther, parseEther, Hex } from "viem";
 import { useMUD } from "@mud/MUDContext";
 import { Btn } from "@frontend/Components/Btn";

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,25 +1,43 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["vite/client"],
+    "types": [
+      "vite/client"
+    ],
     "target": "ESNext",
-    "lib": ["ESNext", "DOM"],
-    "jsx": "react-jsx",
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "module": "esnext",
     "strict": true,
-    "baseUrl": ".",
-    "paths": {
-      "@df/*": ["./src/Shared/*"],
-      "@mud/*": ["./src/mud/*"],
-      "@hooks/*": ["./src/hooks/*"],
-      "@wallet/*": ["./src/wallet/*"],
-      "@frontend/*": ["./src/Frontend/*"],
-      "@backend/*": ["./src/Backend/*"]
-    },
     "strictPropertyInitialization": false,
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "jsx": "react-jsx",
+    "paths": {
+      "@df/*": [
+        "./src/Shared/*"
+      ],
+      "@mud/*": [
+        "./src/mud/*"
+      ],
+      "@hooks/*": [
+        "./src/hooks/*"
+      ],
+      "@wallet/*": [
+        "./src/wallet/*"
+      ],
+      "@frontend/*": [
+        "./src/Frontend/*"
+      ],
+      "@backend/*": [
+        "./src/Backend/*"
+      ]
+    }
   },
-  "include": ["src"]
+  "include": [
+    "./src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
What the title says ☝️ , i'm also leaning into just not inheriting from the `@latticexyz/common/tsconfig.base.json` since it does not do us any good here 🤷, also in case they decided todo changes in their config in the future that may lead to bugs that are a bit hard to find (however these changes will be fixed in a separate PRs)

## Things i want to keep from lattice config in an upcoming PR
- [`noEmit = true`](https://www.typescriptlang.org/tsconfig#noEmit); disables generating js files from ts files under compilation.
- [`noErrorTruncation = true`](https://www.typescriptlang.org/tsconfig#noErrorTruncation); Disable truncating types in error messages.
- [`resolveJsonModule = true`](https://www.typescriptlang.org/tsconfig#resolveJsonModule); Enabled importing JSON files.
- [`forceConsistentCasingInFileNames = true`](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames); Ensures that casing is correct in imports.

## Things i have not yet introduced but will gradually

### Enable JS code
- [`allowJs = true`](https://www.typescriptlang.org/tsconfig#allowJs); Allows JS files to also to be imported in TS code
- [`checkJs = true`](https://www.typescriptlang.org/tsconfig#checkJs); Works in tandem with [allowJs](https://www.typescriptlang.org/tsconfig/#allowJs). When checkJs is enabled then errors are reported in JavaScript files. This is the equivalent of including // @ts-check at the top of all JavaScript files which are included in your project.

### Other Flags
- [`noUnusedParameters = true`](https://www.typescriptlang.org/tsconfig#noUnusedParameters); Report errors on unused parameters in functions.
- [`useUnknownInCatchVariables = true`](https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables); In TypeScript 4.0, support was added to allow changing the type of the variable in a catch clause from any to unknown. Because one cannot guarantee that the object being thrown is a Error subclass ahead of time.
- [`verbatimModuleSyntax = true`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax);  Will enforce the use of `type` before imports that are only references as types, reduces bundle size and makes TSC compile faster.


### Bundler

Change bundler to `ESNext`, however this will require that all our files use the the `.js` extension when importing files. This is the way to go in the future. This was introduced in TS 4.7  and is more aligned with ESM imports and the module system. This is also something also Ryan Dahl regrets when he created NodeJS. 

I also had a talk with lattice in Discord some months ago, where they regret not having used this and want to use this in the future since the JS community is moving along with the ESM module system.

- [ECMAScript Module Support in Node.js](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#esm-nodejs)
- [Regret require without the extension ".js"](https://youtu.be/M3BM9TB-8yA?si=EBfYNPNKChnmZNx1)

