### PR TITLE
TSConfig: Enable no unused variables and function parameters compiler options

### DIFF
--- a/packages/client/docs/TypeScript.md
+++ b/packages/client/docs/TypeScript.md
@@ -20,6 +20,8 @@ Our TypeScript configuration extends the root `tsconfig.json`, which in turn ext
 - [`strictPropertyInitialization = false`](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization); is disabled so that we get no error on properties that are declared but not set in constructor (will enable it in upcoming code, enabled by default by strict mode).
 - [`useDefineForClassFields = false`](https://www.typescriptlang.org/tsconfig#useDefineForClassFields); is disabled so we are not actually emitting standard ECMA compliant class field (we will enable it in upcoming code)
 - [`noErrorTruncation = true`](https://www.typescriptlang.org/tsconfig#noErrorTruncation); Disable truncating types in error messages.
+- [`noUnusedLocals = true`](https://www.typescriptlang.org/tsconfig#noUnusedLocals); Reports on unused local variables.
+- [`noUnusedParameters = true`](https://www.typescriptlang.org/tsconfig#noUnusedParameters); Reports on unused parameters in functions.
 - [`resolveJsonModule = true`](https://www.typescriptlang.org/tsconfig#resolveJsonModule); Enabled importing JSON files.
 - [`forceConsistentCasingInFileNames = true`](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames); Ensures that casing is correct in imports.
 - [`jsx = "react-jsx"`](https://www.typescriptlang.org/tsconfig#jsx); specifies that react-jsx code is generated.

--- a/packages/client/src/Backend/Miner/MinerManager.ts
+++ b/packages/client/src/Backend/Miner/MinerManager.ts
@@ -63,6 +63,8 @@ export class HomePlanetMinerChunkStore implements ChunkStore {
 
 class MinerManager extends EventEmitter {
   private readonly minedChunksStore: ChunkStore;
+
+  // @ts-expect-error `planetRarity` property seems to be unused, double check and remove if redundant
   private readonly planetRarity: number;
 
   private isExploring = false;

--- a/packages/client/src/Frontend/Components/LoadingSpinner.tsx
+++ b/packages/client/src/Frontend/Components/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import _, { useEffect, useState } from "react";
 
 export function LoadingSpinner({
   initialText,

--- a/packages/client/src/Frontend/Components/Text.tsx
+++ b/packages/client/src/Frontend/Components/Text.tsx
@@ -1,11 +1,11 @@
 import { BLOCK_EXPLORER_URL } from "@df/constants";
-import { isLocatable } from "@df/gamelogic";
-import { artifactName, getPlanetName } from "@df/procedural";
+// import { isLocatable } from "@df/gamelogic";
+// import { artifactName, getPlanetName } from "@df/procedural";
 import {
-  Artifact,
-  ArtifactId,
-  Chunk,
-  Planet,
+  // Artifact,
+  // ArtifactId,
+  // Chunk,
+  // Planet,
   Transaction,
   WorldCoords,
 } from "@df/types";
@@ -14,7 +14,7 @@ import styled from "styled-components";
 // import Viewport from '../Game/Viewport';
 import dfstyles from "../Styles/dfstyles";
 // import { useUIManager } from '../Utils/AppHooks';
-import UIEmitter, { UIEmitterEvent } from "../Utils/UIEmitter";
+// import UIEmitter, { UIEmitterEvent } from "../Utils/UIEmitter";
 import { Link } from "./CoreUI";
 
 export function BlinkCursor() {

--- a/packages/client/src/Shared/renderer/Entities/PlanetRenderManager.ts
+++ b/packages/client/src/Shared/renderer/Entities/PlanetRenderManager.ts
@@ -347,11 +347,11 @@ export class PlanetRenderManager implements PlanetRenderManagerType {
     for (let i = 0; i < artifacts.length; i++) {
       const x =
         Math.cos(anglePerArtifact * i + startingAngle + nowAngle) *
-          distanceFromCenterOfPlanet +
+        distanceFromCenterOfPlanet +
         centerW.x;
       const y =
         Math.sin(anglePerArtifact * i + startingAngle + nowAngle) *
-          distanceFromCenterOfPlanet +
+        distanceFromCenterOfPlanet +
         centerW.y;
       if (
         artifacts[i].artifactType === ArtifactType.Avatar
@@ -525,6 +525,7 @@ export class PlanetRenderManager implements PlanetRenderManagerType {
     center: WorldCoords,
     radius: number,
   ) {
+    // @ts-expect-error - Remove circleRenderer if not needed later one
     const { blackDomainRenderer: bR, circleRenderer: cR } = this.renderer;
 
     bR.queueBlackDomain(planet, center, radius);

--- a/packages/client/src/Shared/renderer/Memes.ts
+++ b/packages/client/src/Shared/renderer/Memes.ts
@@ -33,18 +33,21 @@ const chunZhen = {
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const iKunBird = {
   legacy: false,
   topLayer: [URL + "/img/meme/iKunBird.png"],
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const mike = {
   legacy: false,
   topLayer: [URL + "/img/meme/mike.png"],
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const panda = {
   legacy: false,
   topLayer: [URL + "/img/meme/panda.png"],
@@ -57,6 +60,7 @@ const pepe = {
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const pigMan = {
   legacy: false,
   topLayer: [URL + "/img/meme/pigMan.png"],
@@ -69,18 +73,21 @@ const robotCat = {
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const taiKuLa = {
   legacy: false,
   topLayer: [URL + "/img/meme/taiKuLa.png"],
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const wojak1 = {
   legacy: false,
   topLayer: [URL + "/img/meme/wojak1.png"],
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const wojak2 = {
   legacy: false,
   topLayer: [URL + "/img/meme/wojak2.png"],
@@ -93,6 +100,7 @@ const wojak3 = {
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const wojak4 = {
   legacy: false,
   topLayer: [URL + "/img/meme/wojak4.png"],
@@ -111,6 +119,7 @@ const Harold = {
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const TheMerge = {
   legacy: false,
   topLayer: [URL + "/img/meme/TheMerge.png"],
@@ -123,12 +132,14 @@ const Undream = {
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const KakaiKiki = {
   legacy: false,
   topLayer: [URL + "/img/meme/KaikaiKiki.png"],
   bottomLayer: [],
 };
 
+// @ts-ignore - unused
 const SuccessfulKid = {
   legacy: false,
   topLayer: [URL + "/img/meme/sucessful-kid.png"],

--- a/packages/client/src/Shared/renderer/Overlay2DRenderer.ts
+++ b/packages/client/src/Shared/renderer/Overlay2DRenderer.ts
@@ -90,6 +90,7 @@ export class Overlay2DRenderer {
   }
 
   drawArtifactAroundPlanet(
+    // @ts-expect-error `artifact` argument seems to be unused, double check and remove if redundant
     artifact: Artifact,
     coords: CanvasCoords,
     size: number,

--- a/packages/client/src/Shared/renderer/Programs/NoiseProgram.ts
+++ b/packages/client/src/Shared/renderer/Programs/NoiseProgram.ts
@@ -10,6 +10,7 @@ const nV = {
   noise: "v_noise",
 };
 
+// @ts-ignore - unused
 const _noiseVert = glsl`
   precision highp float;
 
@@ -27,6 +28,7 @@ const _noiseVert = glsl`
   }
 `;
 
+// @ts-ignore - unused
 // https://gist.github.com/patriciogonzalezvivo/670c22f3966e662d2f83
 const _noiseFrag = glsl`
   precision highp float;

--- a/packages/client/src/Shared/renderer/TextureManager.ts
+++ b/packages/client/src/Shared/renderer/TextureManager.ts
@@ -201,6 +201,8 @@ function ancientSpriteInfo(): AncientSpriteLocations {
 
   return result as AncientSpriteLocations;
 }
+
+// @ts-expect-error `ancientSpriteLocs` variable seems to be unused, double check and remove if redundant
 const ancientSpriteLocs = ancientSpriteInfo();
 
 const artifactSpriteMap: Map<ArtifactId, SpriteRectangle> = new Map();

--- a/packages/client/src/Shared/renderer/UIRenderer.ts
+++ b/packages/client/src/Shared/renderer/UIRenderer.ts
@@ -39,6 +39,7 @@ export class UIRenderer implements UIRendererType {
       context: uiManager,
       lineRenderer: lR,
       textRenderer: tR,
+      // @ts-expect-error `cr` variable seems to be unused, double check and remove if redundant
       circleRenderer: cR,
     } = this.renderer;
     const mouseDownPlanet = uiManager.getMouseDownPlanet();
@@ -173,5 +174,5 @@ export class UIRenderer implements UIRendererType {
   }
 
   // eslint-disable-next-line
-  flush(): void {}
+  flush(): void { }
 }

--- a/packages/client/src/Shared/serde/artifact.ts
+++ b/packages/client/src/Shared/serde/artifact.ts
@@ -1,17 +1,17 @@
 // import type { DarkForest } from "@df/contracts/typechain";
 import {
-  Artifact,
+  // Artifact,
   ArtifactId,
-  ArtifactPointValues,
-  ArtifactRarity,
-  ArtifactType,
-  Biome,
-  VoyageId,
+  // ArtifactPointValues,
+  // ArtifactRarity,
+  // ArtifactType,
+  // Biome,
+  // VoyageId,
 } from "@df/types";
 import bigInt from "big-integer";
 import type { BigNumber as EthersBN } from "ethers";
-import { address } from "./address";
-import { locationIdFromDecStr, locationIdFromEthersBN } from "./location";
+// import { address } from "./address";
+// import { locationIdFromDecStr, locationIdFromEthersBN } from "./location";
 // import { decodeUpgrade } from "./upgrade";
 
 /**

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -3,7 +3,7 @@
  * for changes in the World state (using the System contracts).
  */
 
-import { Entity, getComponentValue } from "@latticexyz/recs";
+import { getComponentValue } from "@latticexyz/recs";
 import { ClientComponents } from "./createClientComponents";
 import { SetupNetworkResult } from "./setupNetwork";
 import { singletonEntity } from "@latticexyz/store-sync/recs";

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -18,6 +18,8 @@
     "strictPropertyInitialization": false,
     "useDefineForClassFields": false,
     "noErrorTruncation": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
This is a follow up on #14 , and enables the following compiler options:

1.  [`noUnusedLocals = true`](https://www.typescriptlang.org/tsconfig#noUnusedLocals); Reports on unused local variables.
2. [`noUnusedParameters = true`](https://www.typescriptlang.org/tsconfig#noUnusedParameters); Reports on unused parameters in functions.

This helps us reason over the TS code better,  and see what local variables and function parameters that are in use or not, it also helps us see and remove unused code and keeping our codebase tidy 👌 


NOTE: If one want's to keep some code that is currently not in use, however not remove it from the codebase in some file one can always use the `@ts-ignore` directive with a comment, that will turn off the error reporting on it.