### PR TITLE
TSConfig: Enable verbatim module syntax

### DIFF
--- a/packages/client/.eslintrc
+++ b/packages/client/.eslintrc
@@ -6,23 +6,35 @@
     "plugin:react-hooks/recommended",
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:react/recommended",
+    "plugin:react/recommended"
   ],
   "plugins": [
     "react",
     "react-hooks",
     "eslint-plugin-import"
   ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "rules": {
     "react/react-in-jsx-scope": "off",
     "import/order": [
       "error",
       {
-        "groups": ["builtin", "external", "internal"],
+        "groups": [
+          "builtin",
+          "external",
+          "internal"
+        ],
         "newlines-between": "always",
-        "alphabetize": { "order": "asc", "caseInsensitive": true }
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
       }
     ],
     "no-unused-vars": "error"
-  },
+  }
 }

--- a/packages/client/docs/TypeScript.md
+++ b/packages/client/docs/TypeScript.md
@@ -22,6 +22,7 @@ Our TypeScript configuration extends the root `tsconfig.json`, which in turn ext
 - [`noErrorTruncation = true`](https://www.typescriptlang.org/tsconfig#noErrorTruncation); Disable truncating types in error messages.
 - [`resolveJsonModule = true`](https://www.typescriptlang.org/tsconfig#resolveJsonModule); Enabled importing JSON files.
 - [`forceConsistentCasingInFileNames = true`](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames); Ensures that casing is correct in imports.
+- [`verbatimModuleSyntax = true`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax); Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.
 - [`jsx = "react-jsx"`](https://www.typescriptlang.org/tsconfig#jsx); specifies that react-jsx code is generated.
 - [`paths = ["@package-name": ["location"], …`](https://www.typescriptlang.org/tsconfig#jsx); Specifies a set of entries that re-map imports to additional lookup locations.
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -63,6 +63,7 @@
     "@vitejs/plugin-react": "3.1.0",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.0",
+    "eslint-plugin-import": "2.30.0",
     "eslint-plugin-react": "7.31.11",
     "eslint-plugin-react-hooks": "4.6.0",
     "postcss": "8.4.41",

--- a/packages/client/src/Backend/Miner/ChunkUtils.ts
+++ b/packages/client/src/Backend/Miner/ChunkUtils.ts
@@ -1,5 +1,5 @@
-import { Chunk, Rectangle, WorldCoords, WorldLocation } from "@df/types";
-import {
+import type { Chunk, Rectangle, WorldCoords, WorldLocation } from "@df/types";
+import type {
   BucketId,
   ChunkId,
   PersistedChunk,

--- a/packages/client/src/Backend/Miner/MinerManager.ts
+++ b/packages/client/src/Backend/Miner/MinerManager.ts
@@ -1,14 +1,14 @@
 import { perlin } from "@df/hashing";
-import { Chunk, PerlinConfig, Rectangle } from "@df/types";
+import type { Chunk, PerlinConfig, Rectangle } from "@df/types";
 import { EventEmitter } from "events";
 import _ from "lodash";
-import { ChunkStore } from "../../_types/darkforest/api/ChunkStoreTypes";
-import {
+import type { ChunkStore } from "../../_types/darkforest/api/ChunkStoreTypes";
+import type {
   HashConfig,
   MinerWorkerMessage,
 } from "../../_types/global/GlobalTypes";
 import { getChunkKey } from "./ChunkUtils";
-import { MiningPattern } from "./MiningPatterns";
+import type { MiningPattern } from "./MiningPatterns";
 
 export const enum MinerManagerEvent {
   DiscoveredNewChunk = "DiscoveredNewChunk",

--- a/packages/client/src/Backend/Miner/MiningPatterns.ts
+++ b/packages/client/src/Backend/Miner/MiningPatterns.ts
@@ -1,4 +1,4 @@
-import { Rectangle, WorldCoords } from "@df/types";
+import type { Rectangle, WorldCoords } from "@df/types";
 
 export const enum MiningPatternType {
   Home,

--- a/packages/client/src/Backend/Miner/miner.worker.ts
+++ b/packages/client/src/Backend/Miner/miner.worker.ts
@@ -1,10 +1,10 @@
 import { mimcHash, perlin } from "@df/hashing";
 import { locationIdFromBigInt } from "@df/serde";
-import { Chunk, PerlinConfig, Rectangle, WorldLocation } from "@df/types";
+import type { Chunk, PerlinConfig, Rectangle, WorldLocation } from "@df/types";
 import bigInt from "big-integer";
-import { BigInteger } from "big-integer";
+import type { BigInteger } from "big-integer";
 import { LOCATION_ID_UB } from "../../Frontend/Utils/constants";
-import { MinerWorkerMessage } from "../../_types/global/GlobalTypes";
+import type { MinerWorkerMessage } from "../../_types/global/GlobalTypes";
 import { getPlanetLocations } from "./permutation";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/client/src/Backend/Miner/permutation.ts
+++ b/packages/client/src/Backend/Miner/permutation.ts
@@ -1,6 +1,6 @@
 import { fakeHash, perlin, seededRandom } from "@df/hashing";
 import { locationIdFromBigInt } from "@df/serde";
-import { Rectangle, WorldCoords, WorldLocation } from "@df/types";
+import type { Rectangle, WorldCoords, WorldLocation } from "@df/types";
 
 type IdxWithRand = {
   idx: number;

--- a/packages/client/src/Backend/Utils/Coordinates.ts
+++ b/packages/client/src/Backend/Utils/Coordinates.ts
@@ -1,4 +1,4 @@
-import { CanvasCoords, WorldCoords } from "@df/types";
+import type { CanvasCoords, WorldCoords } from "@df/types";
 
 export const coordsEqual = (a: WorldCoords, b: WorldCoords): boolean =>
   a.x === b.x && a.y === b.y;

--- a/packages/client/src/Backend/Utils/SnarkArgsHelper.ts
+++ b/packages/client/src/Backend/Utils/SnarkArgsHelper.ts
@@ -5,11 +5,9 @@ import {
   modPBigIntNative,
   perlin,
 } from "../../Shared/hashing";
-import {
+import type {
   BiomebaseSnarkContractCallArgs,
   BiomebaseSnarkInput,
-  buildContractCallArgs,
-  fakeProof,
   InitSnarkContractCallArgs,
   InitSnarkInput,
   MoveSnarkContractCallArgs,
@@ -18,6 +16,7 @@ import {
   RevealSnarkInput,
   SnarkJSProofAndSignals,
 } from "../../Shared/snarks";
+import { buildContractCallArgs, fakeProof } from "../../Shared/snarks";
 import biomebaseCircuitPath from "../../Shared/snarks/biomebase.wasm";
 import biomebaseZkeyPath from "../../Shared/snarks/biomebase.zkey";
 import initCircuitPath from "../../Shared/snarks/init.wasm";
@@ -26,14 +25,14 @@ import moveCircuitPath from "../../Shared/snarks/move.wasm";
 import moveZkeyPath from "../../Shared/snarks/move.zkey";
 import revealCircuitPath from "../../Shared/snarks/reveal.wasm";
 import revealZkeyPath from "../../Shared/snarks/reveal.zkey";
-import { PerlinConfig } from "../../Shared/types";
+import type { PerlinConfig } from "../../Shared/types";
 import bigInt from "big-integer";
-import { BigInteger } from "big-integer";
+import type { BigInteger } from "big-integer";
 import FastQueue from "fastq";
 import { LRUMap } from "mnemonist";
 import { TerminalTextStyle } from "../../Frontend/Utils/TerminalTypes";
-import { TerminalHandle } from "../../Frontend/Views/Terminal";
-import { HashConfig } from "../../_types/global/GlobalTypes";
+import type { TerminalHandle } from "../../Frontend/Views/Terminal";
+import type { HashConfig } from "../../_types/global/GlobalTypes";
 
 type ZKPTask = {
   taskId: number;

--- a/packages/client/src/Backend/Utils/Utils.ts
+++ b/packages/client/src/Backend/Utils/Utils.ts
@@ -1,13 +1,13 @@
 import { formatNumber } from "../../Shared/gamelogic";
 import {
-  EthAddress,
-  Planet,
+  type EthAddress,
+  type Planet,
   SpaceType,
-  Upgrade,
+  type Upgrade,
   UpgradeBranchName,
 } from "../../Shared/types";
 import bigInt from "big-integer";
-import { BigInteger } from "big-integer";
+import type { BigInteger } from "big-integer";
 import { StatIdx } from "../../_types/global/GlobalTypes";
 
 export const ONE_DAY = 24 * 60 * 60 * 1000;

--- a/packages/client/src/Backend/Utils/WhitelistSnarkArgsHelper.ts
+++ b/packages/client/src/Backend/Utils/WhitelistSnarkArgsHelper.ts
@@ -1,15 +1,15 @@
 import {
   buildContractCallArgs,
-  SnarkJSProofAndSignals,
-  WhitelistSnarkContractCallArgs,
-  WhitelistSnarkInput,
+  type SnarkJSProofAndSignals,
+  type WhitelistSnarkContractCallArgs,
+  type WhitelistSnarkInput,
 } from "../../Shared/snarks";
 import whitelistCircuitPath from "../../Shared/snarks/whitelist.wasm";
 import whitelistZkeyPath from "../../Shared/snarks/whitelist.zkey";
-import { EthAddress } from "../../Shared/types";
-import bigInt, { BigInteger } from "big-integer";
+import type { EthAddress } from "../../Shared/types";
+import bigInt, { type BigInteger } from "big-integer";
 import { TerminalTextStyle } from "../../Frontend/Utils/TerminalTypes";
-import { TerminalHandle } from "../../Frontend/Views/Terminal";
+import type { TerminalHandle } from "../../Frontend/Views/Terminal";
 
 /**
  * Helper method for generating whitelist SNARKS.

--- a/packages/client/src/Frontend/Components/CoreUI.tsx
+++ b/packages/client/src/Frontend/Components/CoreUI.tsx
@@ -1,5 +1,5 @@
 import colors from "color";
-import React, { ChangeEvent, useCallback } from "react";
+import React, { type ChangeEvent, useCallback } from "react";
 import styled, { css } from "styled-components";
 import dfstyles from "../Styles/dfstyles";
 import { DFZIndex } from "../Utils/constants";
@@ -34,16 +34,16 @@ export const TextButton = styled.span`
 
 export const Padded = styled.div`
   ${({
-    left,
-    top,
-    right,
-    bottom,
-  }: {
-    left?: string;
-    top?: string;
-    right?: string;
-    bottom?: string;
-  }) => css`
+  left,
+  top,
+  right,
+  bottom,
+}: {
+  left?: string;
+  top?: string;
+  right?: string;
+  bottom?: string;
+}) => css`
     padding-left: ${left || "8px"};
     padding-top: ${top || "8px"};
     padding-right: ${right || "8px"};
@@ -208,8 +208,8 @@ const LinkImpl = styled.a`
 
     &:hover {
       color: ${colors(color || dfstyles.colors.dfblue)
-        .lighten(0.3)
-        .hex()};
+      .lighten(0.3)
+      .hex()};
     }
   `}
 `;

--- a/packages/client/src/Frontend/Components/Text.tsx
+++ b/packages/client/src/Frontend/Components/Text.tsx
@@ -1,7 +1,7 @@
 import { BLOCK_EXPLORER_URL } from "@df/constants";
 import { isLocatable } from "@df/gamelogic";
 import { artifactName, getPlanetName } from "@df/procedural";
-import {
+import type {
   Artifact,
   ArtifactId,
   Chunk,

--- a/packages/client/src/Frontend/Views/Terminal.tsx
+++ b/packages/client/src/Frontend/Views/Terminal.tsx
@@ -21,7 +21,7 @@ import {
   Text,
   White,
 } from "../Components/Text";
-import { LoadingBarHandle, TextLoadingBar } from "../Components/TextLoadingBar";
+import { type LoadingBarHandle, TextLoadingBar } from "../Components/TextLoadingBar";
 import dfstyles from "../Styles/dfstyles";
 import { isFirefox } from "../Utils/BrowserChecks";
 import { TerminalTextStyle } from "../Utils/TerminalTypes";
@@ -319,7 +319,7 @@ function TerminalImpl(
             ref={inputRef}
             onKeyUp={onKeyUp}
             onKeyDown={preventEnterDefault}
-            onKeyPress={isFirefox() ? () => {} : preventEnterDefault}
+            onKeyPress={isFirefox() ? () => { } : preventEnterDefault}
             value={inputText}
             onChange={(e) => {
               if (userInputEnabled) {
@@ -332,7 +332,7 @@ function TerminalImpl(
           <InputTextArea
             height={0}
             ref={heightMeasureRef}
-            onChange={() => {}}
+            onChange={() => { }}
             value={inputText}
           />
 

--- a/packages/client/src/Shared/constants/index.ts
+++ b/packages/client/src/Shared/constants/index.ts
@@ -22,17 +22,9 @@
  *
  * @packageDocumentation
  */
-import {
-  ArtifactId,
-  ArtifactRarity,
-  ArtifactType,
-  Biome,
-  EthAddress,
-  GasPrices,
-  LocationId,
-  PlanetLevel,
-} from "@df/types";
-import bigInt, { BigInteger } from "big-integer";
+import type { ArtifactId, EthAddress, GasPrices, LocationId } from "@df/types";
+import { ArtifactRarity, ArtifactType, Biome, PlanetLevel } from "@df/types";
+import bigInt, { type BigInteger } from "big-integer";
 
 export const TOKEN_NAME = "ETH";
 export const BLOCKCHAIN_NAME = "Redstone";

--- a/packages/client/src/Shared/gamelogic/artifact.ts
+++ b/packages/client/src/Shared/gamelogic/artifact.ts
@@ -4,21 +4,23 @@ import {
   MIN_SPACESHIP_TYPE,
 } from "@df/constants";
 import { hashToInt } from "@df/serde";
-import {
+import type {
   Abstract,
   Artifact,
   ArtifactId,
+  EthAddress,
+  Planet,
+  RenderedArtifact,
+} from "@df/types";
+import {
   ArtifactRarity,
   ArtifactRarityNames,
   ArtifactType,
   ArtifactTypeNames,
   Biome,
   BiomeNames,
-  EthAddress,
-  Planet,
   PlanetLevel,
   PlanetType,
-  RenderedArtifact,
 } from "@df/types";
 
 export const RelicsList: ArtifactType[] = [

--- a/packages/client/src/Shared/gamelogic/planet.ts
+++ b/packages/client/src/Shared/gamelogic/planet.ts
@@ -1,11 +1,11 @@
 import { EMPTY_ADDRESS } from "@df/constants";
-import {
+import type {
   EmojiFlagBody,
   LocatablePlanet,
   Planet,
   PlanetMessage,
-  PlanetMessageType,
 } from "@df/types";
+import { PlanetMessageType } from "@df/types";
 
 export const getPlanetRank = (planet: Planet | undefined): number => {
   if (!planet) return 0;

--- a/packages/client/src/Shared/hashing/index.ts
+++ b/packages/client/src/Shared/hashing/index.ts
@@ -29,7 +29,7 @@ import { Fraction } from "./fractions/bigFraction";
 import mimcHash, { mimcSponge, modPBigInt, modPBigIntNative } from "./mimc";
 import {
   getRandomGradientAt,
-  IntegerVector,
+  type IntegerVector,
   MAX_PERLIN_VALUE,
   perlin,
   rand,
@@ -38,7 +38,7 @@ import {
 export {
   mimcHash,
   mimcSponge,
-  IntegerVector,
+  type IntegerVector,
   perlin,
   rand,
   getRandomGradientAt,

--- a/packages/client/src/Shared/hashing/mimc.ts
+++ b/packages/client/src/Shared/hashing/mimc.ts
@@ -1,4 +1,4 @@
-import bigInt, { BigInteger } from "big-integer";
+import bigInt, { type BigInteger } from "big-integer";
 
 export const p = bigInt(
   "21888242871839275222246405745257275088548364400416034343698204186575808495617",

--- a/packages/client/src/Shared/hashing/perlin.ts
+++ b/packages/client/src/Shared/hashing/perlin.ts
@@ -1,6 +1,6 @@
-import { PerlinConfig } from "@df/types";
-import BigInt, { BigInteger } from "big-integer";
-import { Fraction, IFraction } from "./fractions/bigFraction";
+import type { PerlinConfig } from "@df/types";
+import BigInt, { type BigInteger } from "big-integer";
+import { Fraction, type IFraction } from "./fractions/bigFraction";
 import { perlinRandHash } from "./mimc";
 
 const TRACK_LCM = false;

--- a/packages/client/src/Shared/procedural/ArtifactProcgen.ts
+++ b/packages/client/src/Shared/procedural/ArtifactProcgen.ts
@@ -1,7 +1,6 @@
 import { EMPTY_ADDRESS, EMPTY_LOCATION_ID } from "@df/constants";
+import type { Artifact, ArtifactId } from "@df/types";
 import {
-  Artifact,
-  ArtifactId,
   artifactNameFromArtifact,
   ArtifactRarity,
   ArtifactType,

--- a/packages/client/src/Shared/procedural/ProcgenUtils.ts
+++ b/packages/client/src/Shared/procedural/ProcgenUtils.ts
@@ -15,24 +15,26 @@ import {
 import { getPlanetRank, isLocatable } from "@df/gamelogic";
 import { seededRandom } from "@df/hashing";
 import { hashToInt } from "@df/serde";
-import {
+import type {
   ArtifactId,
-  AvatarType,
-  AvatarTypeNames,
-  Biome,
   EthAddress,
-  HatType,
   HSLVec,
   LocationId,
-  LogoType,
-  LogoTypeNames,
-  MemeType,
-  MemeTypeNames,
   Planet,
   PlanetCosmeticInfo,
   RGBAVec,
   RGBVec,
   RuinsInfo,
+} from "@df/types";
+import {
+  AvatarType,
+  AvatarTypeNames,
+  Biome,
+  HatType,
+  LogoType,
+  LogoTypeNames,
+  MemeType,
+  MemeTypeNames,
   UpgradeBranchName,
 } from "../types";
 import Noise from "./Noise";

--- a/packages/client/src/Shared/renderer/EngineConsts.ts
+++ b/packages/client/src/Shared/renderer/EngineConsts.ts
@@ -1,5 +1,5 @@
 import { hslToRgb } from "@df/procedural";
-import { RGBAVec, RGBVec } from "@df/types";
+import type { RGBAVec, RGBVec } from "@df/types";
 
 export const engineConsts = {
   fontStyle: "64px monospace",

--- a/packages/client/src/Shared/renderer/EngineUtils.ts
+++ b/packages/client/src/Shared/renderer/EngineUtils.ts
@@ -1,4 +1,5 @@
-import { Planet, RenderZIndex, RGBVec } from "@df/types";
+import type { Planet, RGBVec } from "@df/types";
+import { RenderZIndex } from "@df/types";
 
 /* generic template string which, combined with a vscode package, let us get syntax highlighting. */
 
@@ -127,17 +128,17 @@ export class EngineUtils {
 
   /* makes a 3d quad and writes it into buffer b. saves time from GC. */
   // prettier-ignore
-  public static makeQuadBuffered (
+  public static makeQuadBuffered(
     b: number[], // quadBuffer
     x1: number, y1: number,
     x2: number, y2: number,
     z: number,
   ): void {
-    b[0]  = x1; b[1]  = y1; b[2]  = z;
-    b[3]  = x1; b[4]  = y2; b[5]  = z;
-    b[6]  = x2; b[7]  = y1; b[8]  = z;
+    b[0] = x1; b[1] = y1; b[2] = z;
+    b[3] = x1; b[4] = y2; b[5] = z;
+    b[6] = x2; b[7] = y1; b[8] = z;
 
-    b[9]  = x2; b[10] = y1; b[11] = z;
+    b[9] = x2; b[10] = y1; b[11] = z;
     b[12] = x1; b[13] = y2; b[14] = z;
     b[15] = x2; b[16] = y2; b[17] = z;
   }
@@ -163,7 +164,7 @@ export class EngineUtils {
 
   /* like above, but 2d */
   // prettier-ignore
-  public static makeQuadVec2Buffered (
+  public static makeQuadVec2Buffered(
     b: number[], // quadBuffer
     x1: number, y1: number,
     x2: number, y2: number,
@@ -187,9 +188,9 @@ export class EngineUtils {
     bx1: number, by1: number,
     bx2: number, by2: number,
   ): void {
-    b[0]  = ax1; b[1]  = ay1; b[2]  = bx1; b[3]  = by1;
-    b[4]  = ax1; b[5]  = ay2; b[6]  = bx1; b[7]  = by2;
-    b[8]  = ax2; b[9]  = ay1; b[10] = bx2; b[11] = by1;
+    b[0] = ax1; b[1] = ay1; b[2] = bx1; b[3] = by1;
+    b[4] = ax1; b[5] = ay2; b[6] = bx1; b[7] = by2;
+    b[8] = ax2; b[9] = ay1; b[10] = bx2; b[11] = by1;
 
     b[12] = ax2; b[13] = ay1; b[14] = bx2; b[15] = by1;
     b[16] = ax1; b[17] = ay2; b[18] = bx1; b[19] = by2;

--- a/packages/client/src/Shared/renderer/Entities/AsteroidRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/AsteroidRenderer.ts
@@ -1,13 +1,12 @@
 import { getPlanetCosmetic } from "../../procedural";
-import {
+import type {
   AsteroidRendererType,
   CanvasCoords,
-  DrawMode,
   GameViewport,
   Planet,
-  RendererType,
   RGBVec,
 } from "@df/types";
+import { DrawMode, RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { ASTEROID_PROGRAM_DEFINITION } from "../Programs/AsteroidProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/BackgroundRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/BackgroundRenderer.ts
@@ -1,10 +1,5 @@
-import {
-  BackgroundRendererType,
-  Chunk,
-  RendererType,
-  RGBVec,
-  SpaceType,
-} from "@df/types";
+import type { BackgroundRendererType, Chunk, RGBVec } from "@df/types";
+import { RendererType, SpaceType } from "@df/types";
 import { Renderer } from "../Renderer";
 import { GameGLManager } from "../WebGL/GameGLManager";
 import { RectRenderer } from "./RectRenderer";

--- a/packages/client/src/Shared/renderer/Entities/BeltRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/BeltRenderer.ts
@@ -1,15 +1,15 @@
-import {
+import type {
   BeltRendererType,
   CanvasCoords,
   Planet,
-  RendererType,
   RGBVec,
   WorldCoords,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import autoBind from "auto-bind";
 import { EngineUtils } from "../EngineUtils";
 import {
-  BeltProps,
+  type BeltProps,
   BELT_PROGRAM_DEFINITION,
   propsFromIdx,
 } from "../Programs/BeltProgram";

--- a/packages/client/src/Shared/renderer/Entities/BlackDomainRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/BlackDomainRenderer.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   BlackDomainRendererType,
   CanvasCoords,
   GameViewport,
   Planet,
-  RendererType,
   WorldCoords,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { BLACKDOMAIN_PROGRAM_DEFINITION } from "../Programs/BlackDomainProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/BlueZoneRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/BlueZoneRenderer.ts
@@ -1,5 +1,5 @@
-import { BlueZoneRendererType, RendererType } from "@df/types";
-import { Renderer, RendererGameContext } from "../Renderer";
+import { type BlueZoneRendererType, RendererType } from "@df/types";
+import { Renderer, type RendererGameContext } from "../Renderer";
 import { GameGLManager } from "../WebGL/GameGLManager";
 
 export class BlueZoneRenderer implements BlueZoneRendererType {

--- a/packages/client/src/Shared/renderer/Entities/CaptureZoneRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/CaptureZoneRenderer.ts
@@ -1,5 +1,5 @@
-import { CaptureZoneRendererType, RendererType } from "@df/types";
-import { Renderer, RendererGameContext } from "../Renderer";
+import { type CaptureZoneRendererType, RendererType } from "@df/types";
+import { Renderer, type RendererGameContext } from "../Renderer";
 import { GameGLManager } from "../WebGL/GameGLManager";
 
 export class CaptureZoneRenderer implements CaptureZoneRendererType {

--- a/packages/client/src/Shared/renderer/Entities/CircleRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/CircleRenderer.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   CanvasCoords,
   CircleRendererType,
   GameViewport,
-  RendererType,
   RGBAVec,
   WorldCoords,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { engineConsts } from "../EngineConsts";
 import { EngineUtils } from "../EngineUtils";
 import { CIRCLE_PROGRAM_DEFINITION } from "../Programs/CircleProgram";

--- a/packages/client/src/Shared/renderer/Entities/LineRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/LineRenderer.ts
@@ -1,11 +1,11 @@
 import {
-  CanvasCoords,
+  type CanvasCoords,
   DrawMode,
-  LineRendererType,
+  type LineRendererType,
   RendererType,
   RenderZIndex,
-  RGBAVec,
-  WorldCoords,
+  type RGBAVec,
+  type WorldCoords,
 } from "@df/types";
 import { LINE_PROGRAM_DEFINITION } from "../Programs/LineProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/LinkRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/LinkRenderer.ts
@@ -1,11 +1,5 @@
-import {
-  ArtifactId,
-  ArtifactType,
-  LinkRendererType,
-  LocationId,
-  RendererType,
-  RenderZIndex,
-} from "@df/types";
+import type { ArtifactId, LinkRendererType, LocationId } from "@df/types";
+import { ArtifactType, RendererType, RenderZIndex } from "@df/types";
 import { engineConsts } from "../EngineConsts";
 import { Renderer } from "../Renderer";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/MaskRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/MaskRenderer.ts
@@ -1,4 +1,4 @@
-import { Chunk } from "@df/types";
+import type { Chunk } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { MASK_PROGRAM_DEFINITION } from "../Programs/MaskProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/MineBodyRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/MineBodyRenderer.ts
@@ -1,13 +1,12 @@
 import { getPlanetCosmetic, hslToRgb } from "@df/procedural";
-import {
+import type {
   CanvasCoords,
-  DrawMode,
   MineBodyRendererType,
   Planet,
-  RendererType,
   RGBVec,
   WorldCoords,
 } from "@df/types";
+import { DrawMode, RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { MINE_PROGRAM_DEFINITION } from "../Programs/MineProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/MineRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/MineRenderer.ts
@@ -1,11 +1,11 @@
 import { MAX_PLANET_LEVEL } from "@df/constants";
-import {
+import type {
   CanvasCoords,
   MineRendererType,
   Planet,
-  RendererType,
   WorldCoords,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { engineConsts } from "../EngineConsts";
 import { EngineUtils } from "../EngineUtils";
 import { Renderer } from "../Renderer";

--- a/packages/client/src/Shared/renderer/Entities/PerlinRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/PerlinRenderer.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   Chunk,
   PerlinConfig,
   PerlinRendererType,
   Rectangle,
-  RendererType,
   Vec3,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { PERLIN_PROGRAM_DEFINITION } from "../Programs/PerlinProgram";
 import { AttribManager } from "../WebGL/AttribManager";

--- a/packages/client/src/Shared/renderer/Entities/PerlinUtils.ts
+++ b/packages/client/src/Shared/renderer/Entities/PerlinUtils.ts
@@ -1,5 +1,5 @@
 import { Fraction, getRandomGradientAt, rand } from "@df/hashing";
-import { Abstract, PerlinConfig, Rectangle, WorldCoords } from "@df/types";
+import type { Abstract, PerlinConfig, Rectangle, WorldCoords } from "@df/types";
 
 /* types */
 type Vector = { x: number; y: number };

--- a/packages/client/src/Shared/renderer/Entities/PinkZoneRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/PinkZoneRenderer.ts
@@ -1,5 +1,5 @@
-import { PinkZoneRendererType, RendererType } from "@df/types";
-import { Renderer, RendererGameContext } from "../Renderer";
+import { type PinkZoneRendererType, RendererType } from "@df/types";
+import { Renderer, type RendererGameContext } from "../Renderer";
 import { GameGLManager } from "../WebGL/GameGLManager";
 
 export class PinkZoneRenderer implements PinkZoneRendererType {

--- a/packages/client/src/Shared/renderer/Entities/PlanetRenderManager.ts
+++ b/packages/client/src/Shared/renderer/Entities/PlanetRenderManager.ts
@@ -18,23 +18,25 @@ import {
   memeTypeToNum,
 } from "@df/procedural";
 import { isUnconfirmedMoveTx } from "@df/serde";
-import {
+import type {
   Artifact,
-  ArtifactType,
-  AvatarType,
-  HatType,
   LocatablePlanet,
   LocationId,
-  LogoType,
-  MemeType,
   Planet,
   PlanetRenderInfo,
   PlanetRenderManagerType,
+  WorldCoords,
+} from "@df/types";
+import {
+  ArtifactType,
+  AvatarType,
+  HatType,
+  LogoType,
+  MemeType,
   PlanetType,
   RendererType,
   TextAlign,
   TextAnchor,
-  WorldCoords,
 } from "@df/types";
 import { avatars } from "../Avatars";
 import { engineConsts } from "../EngineConsts";

--- a/packages/client/src/Shared/renderer/Entities/PlanetRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/PlanetRenderer.ts
@@ -1,10 +1,6 @@
 import { getPlanetCosmetic } from "@df/procedural";
-import {
-  Planet,
-  PlanetRendererType,
-  RendererType,
-  WorldCoords,
-} from "@df/types";
+import type { Planet, PlanetRendererType, WorldCoords } from "@df/types";
+import { RendererType } from "@df/types";
 import { mat4 } from "gl-matrix";
 import { engineConsts } from "../EngineConsts";
 import { EngineUtils } from "../EngineUtils";

--- a/packages/client/src/Shared/renderer/Entities/QuasarBodyRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/QuasarBodyRenderer.ts
@@ -1,11 +1,11 @@
 import { getPlanetCosmetic } from "@df/procedural";
-import {
+import type {
   CanvasCoords,
   Planet,
   QuasarBodyRendererType,
-  RendererType,
   WorldCoords,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { QUASARBODY_PROGRAM_DEFINITION } from "../Programs/QuasarBodyProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/QuasarRayRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/QuasarRayRenderer.ts
@@ -1,11 +1,11 @@
 import { getPlanetCosmetic } from "@df/procedural";
-import {
+import type {
   CanvasCoords,
   Planet,
   QuasarRayRendererType,
-  RendererType,
   WorldCoords,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { QUASARRAY_PROGRAM_DEFINITION } from "../Programs/QuasarRayProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/QuasarRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/QuasarRenderer.ts
@@ -1,9 +1,5 @@
-import {
-  Planet,
-  QuasarRendererType,
-  RendererType,
-  WorldCoords,
-} from "@df/types";
+import type { Planet, QuasarRendererType, WorldCoords } from "@df/types";
+import { RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { Renderer } from "../Renderer";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/RectRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/RectRenderer.ts
@@ -1,12 +1,11 @@
-import {
+import type {
   CanvasCoords,
   Chunk,
   RectRendererType,
-  RendererType,
-  RenderZIndex,
   RGBVec,
   WorldCoords,
 } from "@df/types";
+import { RendererType, RenderZIndex } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { RECT_PROGRAM_DEFINITION } from "../Programs/RectProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/RingRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/RingRenderer.ts
@@ -1,16 +1,16 @@
-import {
+import type {
   CanvasCoords,
   GameViewport,
   Planet,
-  RendererType,
   RGBVec,
   RingRendererType,
   WorldCoords,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import {
   propsFromIdx,
-  RingProps,
+  type RingProps,
   RING_PROGRAM_DEFINITION,
 } from "../Programs/RingProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/RuinsRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/RuinsRenderer.ts
@@ -1,13 +1,12 @@
 import { getPlanetCosmetic } from "@df/procedural";
-import {
+import type {
   CanvasCoords,
   Planet,
-  PlanetLevel,
-  RendererType,
   RGBVec,
   RuinsRendererType,
   WorldCoords,
 } from "@df/types";
+import { PlanetLevel, RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { RUINS_PROGRAM_DEFINITION } from "../Programs/RuinsProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/SpaceRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/SpaceRenderer.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   Chunk,
   PerlinConfig,
   Rectangle,
-  RendererType,
   SpaceRendererType,
   Vec3,
 } from "@df/types";
+import { RendererType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { SPACE_PROGRAM_DEFINITION } from "../Programs/SpaceProgram";
 import { AttribManager } from "../WebGL/AttribManager";

--- a/packages/client/src/Shared/renderer/Entities/SpacetimeRipRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/SpacetimeRipRenderer.ts
@@ -1,12 +1,11 @@
 import { getPlanetCosmetic } from "@df/procedural";
-import {
+import type {
   CanvasCoords,
   Planet,
-  RendererType,
   SpacetimeRipRendererType,
-  SpaceType,
   WorldCoords,
 } from "@df/types";
+import { RendererType, SpaceType } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { SPACETIMERIP_PROGRAM_DEFINITION } from "../Programs/SpacetimeRipProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/SpriteRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/SpriteRenderer.ts
@@ -1,16 +1,15 @@
 import { isUnconfirmedMoveTx } from "@df/serde";
-import {
+import type {
   Artifact,
-  ArtifactRarity,
   CanvasCoords,
   GameViewport,
   RenderedArtifact,
-  RendererType,
   RGBAVec,
   RGBVec,
   SpriteRendererType,
   WorldCoords,
 } from "@df/types";
+import { ArtifactRarity, RendererType } from "@df/types";
 import { engineConsts } from "../EngineConsts";
 import { EngineUtils } from "../EngineUtils";
 import { SPRITE_PROGRAM_DEFINITION } from "../Programs/SpriteProgram";
@@ -18,7 +17,7 @@ import {
   loadArtifactAtlas,
   loadArtifactThumbAtlas,
   spriteFromArtifact,
-  SpriteRectangle,
+  type SpriteRectangle,
 } from "../TextureManager";
 import { GenericRenderer } from "../WebGL/GenericRenderer";
 import { WebGLManager } from "../WebGL/WebGLManager";

--- a/packages/client/src/Shared/renderer/Entities/TextRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/TextRenderer.ts
@@ -1,13 +1,10 @@
-import {
+import type {
   CanvasCoords,
-  RendererType,
-  RenderZIndex,
   RGBAVec,
-  TextAlign,
-  TextAnchor,
   TextRendererType,
   WorldCoords,
 } from "@df/types";
+import { RendererType, RenderZIndex, TextAlign, TextAnchor } from "@df/types";
 import { engineConsts } from "../EngineConsts";
 import { EngineUtils } from "../EngineUtils";
 import { TEXT_PROGRAM_DEFINITION } from "../Programs/TextProgram";

--- a/packages/client/src/Shared/renderer/Entities/UnminedRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/UnminedRenderer.ts
@@ -1,10 +1,5 @@
-import {
-  CanvasCoords,
-  RendererType,
-  RenderZIndex,
-  RGBVec,
-  UnminedRendererType,
-} from "@df/types";
+import type { CanvasCoords, RGBVec, UnminedRendererType } from "@df/types";
+import { RendererType, RenderZIndex } from "@df/types";
 import { EngineUtils } from "../EngineUtils";
 import { UNMINED_PROGRAM_DEFINITION } from "../Programs/UnminedProgram";
 import { GameGLManager } from "../WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/Entities/VoyageRenderer.ts
+++ b/packages/client/src/Shared/renderer/Entities/VoyageRenderer.ts
@@ -1,17 +1,19 @@
 import { EMPTY_ADDRESS } from "@df/constants";
 import { formatNumber, hasOwner } from "@df/gamelogic";
 import { getOwnerColorVec } from "@df/procedural";
-import {
-  ArtifactType,
+import type {
   LocationId,
   Planet,
   Player,
   QueuedArrival,
+  VoyageRendererType,
+} from "@df/types";
+import {
+  ArtifactType,
   RendererType,
   RenderZIndex,
   TextAlign,
   TextAnchor,
-  VoyageRendererType,
 } from "@df/types";
 import { engineConsts } from "../EngineConsts";
 import { Renderer } from "../Renderer";

--- a/packages/client/src/Shared/renderer/Overlay2DRenderer.ts
+++ b/packages/client/src/Shared/renderer/Overlay2DRenderer.ts
@@ -9,17 +9,16 @@ import {
   numToLogoType,
   numToMemeType,
 } from "@df/procedural";
-import {
+import type {
   Artifact,
   CanvasCoords,
   Chunk,
   EmojiFlagBody,
-  LogoType,
   PlanetMessage,
   PlanetRenderInfo,
-  TextAlign,
   WorldCoords,
 } from "@df/types";
+import { LogoType, TextAlign } from "@df/types";
 import { avatarFromType } from "./Avatars";
 import { engineConsts } from "./EngineConsts";
 import { hatFromType } from "./Hats";

--- a/packages/client/src/Shared/renderer/Programs/GlassProgram.ts
+++ b/packages/client/src/Shared/renderer/Programs/GlassProgram.ts
@@ -1,4 +1,4 @@
-import { AttribProps, AttribType } from "@df/types";
+import { type AttribProps, AttribType } from "@df/types";
 import { glsl } from "../EngineUtils";
 import { ProgramUtils } from "../WebGL/ProgramUtils";
 

--- a/packages/client/src/Shared/renderer/Programs/PlanetProgram.ts
+++ b/packages/client/src/Shared/renderer/Programs/PlanetProgram.ts
@@ -1,5 +1,5 @@
 import { isLocatable } from "@df/gamelogic";
-import { AttribType, Biome, Planet, UniformType } from "@df/types";
+import { AttribType, Biome, type Planet, UniformType } from "@df/types";
 import { glsl } from "../EngineUtils";
 import { ShaderMixins } from "../WebGL/ShaderMixins";
 

--- a/packages/client/src/Shared/renderer/Renderer.ts
+++ b/packages/client/src/Shared/renderer/Renderer.ts
@@ -1,7 +1,6 @@
-import {
+import type {
   Artifact,
   ArtifactId,
-  ArtifactType,
   AsteroidRendererType,
   BackgroundRendererType,
   BaseRenderer,
@@ -29,7 +28,6 @@ import {
   PinkZone,
   PinkZoneRendererType,
   Planet,
-  PlanetLevel,
   PlanetRendererType,
   PlanetRenderInfo,
   PlanetRenderManagerType,
@@ -39,13 +37,10 @@ import {
   QuasarRendererType,
   QueuedArrival,
   RectRendererType,
-  RendererType,
   RingRendererType,
   RuinsRendererType,
-  Setting,
   SpaceRendererType,
   SpacetimeRipRendererType,
-  SpaceType,
   SpriteRendererType,
   TextRendererType,
   Transaction,
@@ -56,6 +51,13 @@ import {
   VoyageRendererType,
   WorldCoords,
   WorldLocation,
+} from "@df/types";
+import {
+  ArtifactType,
+  PlanetLevel,
+  RendererType,
+  Setting,
+  SpaceType,
 } from "@df/types";
 import autoBind from "auto-bind";
 import { AsteroidRenderer } from "./Entities/AsteroidRenderer";

--- a/packages/client/src/Shared/renderer/RendererTypeAssertions.ts
+++ b/packages/client/src/Shared/renderer/RendererTypeAssertions.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AsteroidRendererType,
   BackgroundRendererType,
   BaseRenderer,
@@ -19,7 +19,6 @@ import {
   QuasarRayRendererType,
   QuasarRendererType,
   RectRendererType,
-  RendererType,
   RingRendererType,
   RuinsRendererType,
   SpaceRendererType,
@@ -30,6 +29,7 @@ import {
   UnminedRendererType,
   VoyageRendererType,
 } from "@df/types";
+import { RendererType } from "@df/types";
 
 export function isPlanetRenderer(
   renderer: BaseRenderer,

--- a/packages/client/src/Shared/renderer/TextureManager.ts
+++ b/packages/client/src/Shared/renderer/TextureManager.ts
@@ -1,12 +1,7 @@
 import { MAX_ARTIFACT_TYPE, MAX_BIOME, MIN_ARTIFACT_TYPE } from "@df/constants";
 import { isBasic, isRelic, isSpaceShip } from "@df/gamelogic";
-import {
-  ArtifactId,
-  ArtifactRarity,
-  ArtifactType,
-  Biome,
-  RenderedArtifact,
-} from "@df/types";
+import type { ArtifactId, RenderedArtifact } from "@df/types";
+import { ArtifactRarity, ArtifactType, Biome } from "@df/types";
 
 export const ARTIFACTS_URL = "/public/sprites/artifacts.png";
 export const ARTIFACTS_THUMBS_URL = "/public/sprites/artifactthumbs.png";

--- a/packages/client/src/Shared/renderer/UIRenderer.ts
+++ b/packages/client/src/Shared/renderer/UIRenderer.ts
@@ -1,14 +1,7 @@
 import { isLocatable } from "@df/gamelogic";
 import { isUnconfirmedMoveTx } from "@df/serde";
-import {
-  ArtifactType,
-  Planet,
-  RendererType,
-  RenderZIndex,
-  RGBVec,
-  UIRendererType,
-  WorldCoords,
-} from "@df/types";
+import type { Planet, RGBVec, UIRendererType, WorldCoords } from "@df/types";
+import { ArtifactType, RendererType, RenderZIndex } from "@df/types";
 import { engineConsts } from "./EngineConsts";
 import { Renderer } from "./Renderer";
 import { GameGLManager } from "./WebGL/GameGLManager";

--- a/packages/client/src/Shared/renderer/WebGL/AttribManager.ts
+++ b/packages/client/src/Shared/renderer/WebGL/AttribManager.ts
@@ -1,4 +1,4 @@
-import { AttribProps } from "@df/types";
+import type { AttribProps } from "@df/types";
 import { AttribArray } from "./AttribArray";
 
 /**

--- a/packages/client/src/Shared/renderer/WebGL/GenericRenderer.ts
+++ b/packages/client/src/Shared/renderer/WebGL/GenericRenderer.ts
@@ -1,9 +1,9 @@
 import {
-  AttribProps,
+  type AttribProps,
   DrawMode,
-  UniformProps,
+  type UniformProps,
   UniformType,
-  Vec3,
+  type Vec3,
 } from "@df/types";
 import { mat3, mat4 } from "gl-matrix";
 import { AttribManager } from "./AttribManager";

--- a/packages/client/src/Shared/renderer/WebGL/WebGLManager.ts
+++ b/packages/client/src/Shared/renderer/WebGL/WebGLManager.ts
@@ -1,4 +1,4 @@
-import { RGBAVec } from "@df/types";
+import type { RGBAVec } from "@df/types";
 import autoBind from "auto-bind";
 import { mat4 } from "gl-matrix";
 
@@ -31,7 +31,7 @@ export class WebGLManager {
     // projects xy onto clip space and also compresses z
 
     // prettier-ignore
-    mat4.set(this.projectionMatrix, 
+    mat4.set(this.projectionMatrix,
       2 / width, 0, 0, 0,
       0, -2 / height, 0, 0,
       0, 0, 1 / depth, 0, // TODO make it so that positive is in front

--- a/packages/client/src/Shared/serde/artifact.ts
+++ b/packages/client/src/Shared/serde/artifact.ts
@@ -1,17 +1,16 @@
 // import type { DarkForest } from "@df/contracts/typechain";
-import {
+import type {
   Artifact,
   ArtifactId,
   ArtifactPointValues,
-  ArtifactRarity,
-  ArtifactType,
-  Biome,
   VoyageId,
 } from "@df/types";
+import { ArtifactRarity, ArtifactType, Biome } from "@df/types";
 import bigInt from "big-integer";
 import type { BigNumber as EthersBN } from "ethers";
 import { address } from "./address";
 import { locationIdFromDecStr, locationIdFromEthersBN } from "./location";
+import type { from } from "rxjs";
 // import { decodeUpgrade } from "./upgrade";
 
 /**

--- a/packages/client/src/Shared/serde/event.ts
+++ b/packages/client/src/Shared/serde/event.ts
@@ -1,4 +1,4 @@
-import { AutoGasSetting, NetworkEvent } from "@df/types";
+import { AutoGasSetting, type NetworkEvent } from "@df/types";
 
 /**
  * Returns whether or not the given event is an instance of {@link NetworkEvent}. Not super

--- a/packages/client/src/Shared/serde/location.ts
+++ b/packages/client/src/Shared/serde/location.ts
@@ -1,6 +1,6 @@
 import { LOCATION_ID_UB } from "@df/constants";
 import type { LocationId } from "@df/types";
-import bigInt, { BigInteger } from "big-integer";
+import bigInt, { type BigInteger } from "big-integer";
 import type { BigNumber as EthersBN } from "ethers";
 
 /**

--- a/packages/client/src/Shared/serde/transactions.ts
+++ b/packages/client/src/Shared/serde/transactions.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Transaction,
   TxIntent,
   UnconfirmedAcceptApplication,

--- a/packages/client/src/Shared/ui/DarkForestIcon.ts
+++ b/packages/client/src/Shared/ui/DarkForestIcon.ts
@@ -1,4 +1,4 @@
-import { Abstract } from "@df/types";
+import type { Abstract } from "@df/types";
 import { css, LitElement, nothing, svg, unsafeCSS } from "lit";
 import * as dfstyles from "./styles";
 

--- a/packages/client/src/Shared/ui/DarkForestModal.ts
+++ b/packages/client/src/Shared/ui/DarkForestModal.ts
@@ -1,4 +1,11 @@
-import { css, html, LitElement, nothing, PropertyValues, unsafeCSS } from "lit";
+import {
+  css,
+  html,
+  LitElement,
+  nothing,
+  type PropertyValues,
+  unsafeCSS,
+} from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import * as dfstyles from "./styles";

--- a/packages/client/src/Shared/ui/DarkForestSlider.ts
+++ b/packages/client/src/Shared/ui/DarkForestSlider.ts
@@ -3,7 +3,7 @@ import {
   Slider,
   SliderHandle,
 } from "@spectrum-web-components/slider";
-import { css, CSSResultArray, unsafeCSS } from "lit";
+import { css, type CSSResultArray, unsafeCSS } from "lit";
 import * as dfstyles from "./styles";
 
 export class DarkForestSlider extends Slider {

--- a/packages/client/src/_types/darkforest/api/ContractsAPITypes.ts
+++ b/packages/client/src/_types/darkforest/api/ContractsAPITypes.ts
@@ -1,4 +1,8 @@
-import { ArtifactPointValues, EthAddress, UpgradeBranches } from "@df/types";
+import type {
+  ArtifactPointValues,
+  EthAddress,
+  UpgradeBranches,
+} from "@df/types";
 import { BigNumber as EthersBN } from "ethers";
 
 export const enum ZKArgIdx {

--- a/packages/client/src/_types/global/GlobalTypes.ts
+++ b/packages/client/src/_types/global/GlobalTypes.ts
@@ -1,5 +1,5 @@
-import { Rectangle } from "@df/types";
-import { Dispatch, SetStateAction } from "react";
+import type { Rectangle } from "@df/types";
+import type { Dispatch, SetStateAction } from "react";
 import GameUIManager from "../../Backend/GameLogic/GameUIManager";
 import GameManager from "../../Backend/GameLogic/GameManager";
 

--- a/packages/client/src/hooks/useBalance.ts
+++ b/packages/client/src/hooks/useBalance.ts
@@ -1,13 +1,14 @@
-import { useCallback, useState } from "react";
-import { useAccount, useBalance } from "wagmi";
-import { useMUD } from "../mud/MUDContext";
-import { formatEther } from "viem";
 import {
   LOW_BALANCE_THRESHOLD,
   MINIMUM_BALANCE,
   RECOMMENDED_BALANCE,
   zeroAddress,
 } from "@wallet/utils";
+import { useCallback, useState } from "react";
+import { formatEther } from "viem";
+import { useAccount, useBalance } from "wagmi";
+
+import { useMUD } from "../mud/MUDContext";
 
 // You can define a threshold constant for low balance
 

--- a/packages/client/src/hooks/useStore.ts
+++ b/packages/client/src/hooks/useStore.ts
@@ -1,5 +1,5 @@
 import IWorldAbi from "contracts/out/IWorld.sol/IWorld.abi.json";
-import {
+import type {
   GetContractReturnType,
   PublicClient,
   Transport,
@@ -8,13 +8,12 @@ import {
   Address,
   Account,
 } from "viem";
-
+import type { Config } from "wagmi";
 import { create } from "zustand";
 // import { HeadlessLayer } from "./layers/Headless";
 // import { LocalLayer } from "./layers/Local";
 // import { NetworkLayer } from "./layers/Network";
 // import { PhaserLayer } from "./layers/Renderer/Phaser";
-import { Config } from "wagmi";
 
 // export type ContractType = GetContractReturnType<typeof IWorldAbi, PublicClient, Address>;
 export type ContractType = GetContractReturnType<

--- a/packages/client/src/mud/MUDContext.tsx
+++ b/packages/client/src/mud/MUDContext.tsx
@@ -1,5 +1,5 @@
-import { createContext, ReactNode, useContext } from "react";
-import { SetupResult } from "./setup";
+import { createContext, type ReactNode, useContext } from "react";
+import type { SetupResult } from "./setup";
 
 const MUDContext = createContext<SetupResult | null>(null);
 

--- a/packages/client/src/mud/createClientComponents.ts
+++ b/packages/client/src/mud/createClientComponents.ts
@@ -9,7 +9,7 @@
  * an onchain component.
  */
 
-import { SetupNetworkResult } from "./setupNetwork";
+import type { SetupNetworkResult } from "./setupNetwork";
 
 export type ClientComponents = ReturnType<typeof createClientComponents>;
 

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -3,11 +3,12 @@
  * for changes in the World state (using the System contracts).
  */
 
-import { Entity, getComponentValue } from "@latticexyz/recs";
-import { ClientComponents } from "./createClientComponents";
-import { SetupNetworkResult } from "./setupNetwork";
+import { type Entity, getComponentValue } from "@latticexyz/recs";
 import { singletonEntity } from "@latticexyz/store-sync/recs";
-import { Address } from "viem";
+import type { Address } from "viem";
+
+import type { ClientComponents } from "./createClientComponents";
+import type { SetupNetworkResult } from "./setupNetwork";
 
 export type SystemCalls = ReturnType<typeof createSystemCalls>;
 interface Proof {
@@ -94,7 +95,7 @@ export function createSystemCalls(
     planetType: PlanetType,
     spaceType: SpaceType,
     population: number,
-    silver: number
+    silver: number,
   ): Promise<void> => {
     try {
       // Call the createPlanet function on the contract
@@ -127,7 +128,7 @@ export function createSystemCalls(
     moveInput: MoveInput,
     population: number,
     silver: number,
-    artifact: number
+    artifact: number,
   ): Promise<number> => {
     try {
       // Call the move function on the contract

--- a/packages/client/src/mud/getNetworkConfig.ts
+++ b/packages/client/src/mud/getNetworkConfig.ts
@@ -21,9 +21,10 @@
  * The supported chains.
  * By default, there are only two chains here:
  */
-import { supportedChains } from "./supportedChains";
-import { Wallet } from "ethers";
 import worldsJson from "contracts/worlds.json";
+import { Wallet } from "ethers";
+
+import { supportedChains } from "./supportedChains";
 // import { Entity } from "@latticexyz/recs";
 
 export type NetworkConfig = Awaited<ReturnType<typeof getNetworkConfig>>;

--- a/packages/client/src/mud/setupNetwork.ts
+++ b/packages/client/src/mud/setupNetwork.ts
@@ -3,31 +3,15 @@
  * (https://viem.sh/docs/getting-started.html).
  * This line imports the functions we need from it.
  */
-import {
-  createPublicClient,
-  fallback,
-  webSocket,
-  http,
-  createWalletClient,
-  Hex,
-  ClientConfig,
-  getContract,
-} from "viem";
-import { encodeEntity, syncToRecs } from "@latticexyz/store-sync/recs";
 
-import { getNetworkConfig } from "./getNetworkConfig";
-import { world } from "./world";
-import IWorldAbi from "contracts/out/IWorld.sol/IWorld.abi.json";
 import {
   createBurnerAccount,
   transportObserver,
-  ContractWrite,
+  type ContractWrite,
 } from "@latticexyz/common";
 import { transactionQueue, writeObserver } from "@latticexyz/common/actions";
-
-import { Subject, share } from "rxjs";
+import { encodeEntity, syncToRecs } from "@latticexyz/store-sync/recs";
 import { syncToZustand } from "@latticexyz/store-sync/zustand";
-
 /*
  * Import our MUD config, which includes strong types for
  * our tables and other config options. We use this to generate
@@ -37,6 +21,21 @@ import { syncToZustand } from "@latticexyz/store-sync/zustand";
  * for the source of this information.
  */
 import mudConfig from "contracts/mud.config";
+import IWorldAbi from "contracts/out/IWorld.sol/IWorld.abi.json";
+import { Subject, share } from "rxjs";
+import {
+  createPublicClient,
+  fallback,
+  webSocket,
+  http,
+  createWalletClient,
+  type Hex,
+  type ClientConfig,
+  getContract,
+} from "viem";
+
+import { getNetworkConfig } from "./getNetworkConfig";
+import { world } from "./world";
 
 export type SetupNetworkResult = Awaited<ReturnType<typeof setupNetwork>>;
 

--- a/packages/client/src/mud/supportedChains.ts
+++ b/packages/client/src/mud/supportedChains.ts
@@ -12,7 +12,7 @@
  */
 
 import {
-  MUDChain,
+  type MUDChain,
   mudFoundry,
   redstone,
   garnet,

--- a/packages/client/src/wallet/utils.ts
+++ b/packages/client/src/wallet/utils.ts
@@ -1,4 +1,4 @@
-import { numberToHex, padHex, parseEther, Hex } from "viem";
+import { numberToHex, padHex, parseEther, type Hex } from "viem";
 
 export const MINIMUM_BALANCE = parseEther("0.000006");
 export const LOW_BALANCE_THRESHOLD = parseEther("0.0005");

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,47 +2,28 @@
   "compilerOptions": {
     "noEmit": true,
     "skipLibCheck": true,
-    "types": [
-      "vite/client"
-    ],
+    "types": ["vite/client"],
     "module": "ESNext",
     "esModuleInterop": true,
     "moduleResolution": "Bundler",
     "target": "ESNext",
-    "lib": [
-      "ESNext",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "strict": true,
     "strictPropertyInitialization": false,
     "useDefineForClassFields": false,
     "noErrorTruncation": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
     "jsx": "react-jsx",
     "paths": {
-      "@df/*": [
-        "./src/Shared/*"
-      ],
-      "@mud/*": [
-        "./src/mud/*"
-      ],
-      "@hooks/*": [
-        "./src/hooks/*"
-      ],
-      "@wallet/*": [
-        "./src/wallet/*"
-      ],
-      "@frontend/*": [
-        "./src/Frontend/*"
-      ],
-      "@backend/*": [
-        "./src/Backend/*"
-      ]
+      "@df/*": ["./src/Shared/*"],
+      "@mud/*": ["./src/mud/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@wallet/*": ["./src/wallet/*"],
+      "@frontend/*": ["./src/Frontend/*"],
+      "@backend/*": ["./src/Backend/*"]
     }
   },
-  "include": [
-    "./src/**/*.ts"
-  ]
+  "include": ["./src/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       eslint:
         specifier: 8.57.0
         version: 8.57.0
+      eslint-plugin-import:
+        specifier: 2.30.0
+        version: 2.30.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)
       eslint-plugin-react:
         specifier: 7.31.11
         version: 7.31.11(eslint@8.57.0)
@@ -2687,6 +2690,9 @@ packages:
     resolution: {integrity: sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==}
     engines: {node: '>=14.0.0'}
 
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
   '@safe-global/safe-apps-provider@0.18.3':
     resolution: {integrity: sha512-f/0cNv3S4v7p8rowAjj0hDCg8Q8P/wBjp5twkNWeBdvd0RDr7BuRBPPk74LCqmjQ82P+1ltLlkmVFSmxTIT7XQ==}
 
@@ -3122,6 +3128,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
   '@types/lodash@4.17.7':
     resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
 
@@ -3502,6 +3511,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  array.prototype.findlastindex@1.2.5:
+    resolution: {integrity: sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==}
+    engines: {node: '>= 0.4'}
 
   array.prototype.flat@1.3.2:
     resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
@@ -4052,6 +4065,14 @@ packages:
       supports-color:
         optional: true
 
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
     engines: {node: '>=6.0'}
@@ -4367,6 +4388,40 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-import-resolver-node@0.3.9:
+    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
+
+  eslint-module-utils@2.11.0:
+    resolution: {integrity: sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import@2.30.0:
+    resolution: {integrity: sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
 
   eslint-plugin-react-hooks@4.6.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
@@ -5231,6 +5286,10 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -5830,6 +5889,10 @@ packages:
 
   object.fromentries@2.0.8:
     resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
     engines: {node: '>= 0.4'}
 
   object.hasown@1.1.4:
@@ -6930,6 +6993,10 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
@@ -7116,6 +7183,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -10242,7 +10312,7 @@ snapshots:
 
   '@metamask/safe-event-emitter@3.1.1': {}
 
-  '@metamask/sdk-communication-layer@0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@metamask/sdk-communication-layer@0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5)':
     dependencies:
       bufferutil: 4.0.8
       cross-fetch: 4.0.0
@@ -10278,7 +10348,7 @@ snapshots:
     dependencies:
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
-      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5)
       '@metamask/sdk-install-modal-web': 0.26.5(i18next@23.11.5)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.22)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10))(react@18.2.0)
       '@types/dom-screen-wake-lock': 1.0.3
       bowser: 2.11.0
@@ -10313,7 +10383,7 @@ snapshots:
     dependencies:
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
-      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5)
       '@metamask/sdk-install-modal-web': 0.26.5(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/dom-screen-wake-lock': 1.0.3
       bowser: 2.11.0
@@ -11569,6 +11639,8 @@ snapshots:
 
   '@remix-run/router@1.19.1': {}
 
+  '@rtsao/scc@1.1.0': {}
+
   '@safe-global/safe-apps-provider@0.18.3(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)':
     dependencies:
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -12212,6 +12284,8 @@ snapshots:
       '@types/istanbul-lib-report': 3.0.3
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/json5@0.0.29': {}
 
   '@types/lodash@4.17.7': {}
 
@@ -12998,6 +13072,15 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  array.prototype.findlastindex@1.2.5:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      es-shim-unscopables: 1.0.2
+
   array.prototype.flat@1.3.2:
     dependencies:
       call-bind: 1.0.7
@@ -13584,6 +13667,10 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.3.6(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
@@ -13894,6 +13981,52 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-import-resolver-node@0.3.9:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.15.1
+      resolve: 1.22.8
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.1.1(eslint@8.57.0)(typescript@5.4.2)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      hasown: 2.0.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.1.1(eslint@8.57.0)(typescript@5.4.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
 
   eslint-plugin-react-hooks@4.6.0(eslint@8.57.0):
     dependencies:
@@ -14754,7 +14887,7 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isows@1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)):
+  isows@1.0.4(ws@8.17.1):
     dependencies:
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
@@ -14904,6 +15037,10 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
 
   json5@2.2.3: {}
 
@@ -15603,6 +15740,12 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
 
   object.hasown@1.1.4:
     dependencies:
@@ -16780,6 +16923,8 @@ snapshots:
     dependencies:
       ansi-regex: 6.0.1
 
+  strip-bom@3.0.0: {}
+
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@3.0.0: {}
@@ -16977,6 +17122,13 @@ snapshots:
       typescript: 5.4.2
 
   ts-interface-checker@0.1.13: {}
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@1.14.1: {}
 
@@ -17240,7 +17392,7 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
       abitype: 1.0.5(typescript@5.4.2)(zod@3.23.8)
-      isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      isows: 1.0.4(ws@8.17.1)
       webauthn-p256: 0.0.5
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:


### PR DESCRIPTION
This is a follow up on #14 , and enables the following compiler option:

- [`verbatimModuleSyntax = true`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax); Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.

### tldr;
1. It makes the core more explicit about what are used as type and not
2. It helps the TypeScript compiler removing types under compilation, and also it makes the compiler work faster since it knows explicitely what's used as a type and not ahead of time, and does need spend time infering whether a imported variable will be used or not as variable under compilation phase. 

Read more here https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#--verbatimmodulesyntax14

### Changes in file
Lot's of file where changed, however it's import as type and secondarly prettier have been run on the files.

### Before and After
Works as before.