### PR TITLE
fix: react no longer required to be imported from tsx or jsx files

### DIFF
--- a/packages/client/.eslintrc
+++ b/packages/client/.eslintrc
@@ -19,6 +19,7 @@
     }
   },
   "rules": {
+    "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "import/order": [
       "error",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   BrowserRouter as Router,
   Routes,

--- a/packages/client/src/Frontend/Components/AncientLabel.tsx
+++ b/packages/client/src/Frontend/Components/AncientLabel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 /* ancient label */
 import styled, { css, keyframes } from "styled-components";
 import { ANCIENT_BLUE, ANCIENT_PURPLE } from "../Styles/Colors";

--- a/packages/client/src/Frontend/Components/ArtifactImage.tsx
+++ b/packages/client/src/Frontend/Components/ArtifactImage.tsx
@@ -1,12 +1,12 @@
 import { ArtifactFileColor, artifactFileName } from "@df/gamelogic";
-import { Artifact } from "@df/types";
-import React from "react";
+import type { Artifact } from "@df/types";
 import styled, { css } from "styled-components";
 import dfstyles from "../Styles/dfstyles";
 
 // export const ARTIFACT_URL = 'https://d2wspbczt15cqu.cloudfront.net/v0.6.0-artifacts/';
 export const ARTIFACT_URL = "/public/df_ares_artifact_icons/";
 
+// @ts-ignore unused
 function getArtifactUrl(
   thumb: boolean,
   artifact: Artifact,
@@ -19,8 +19,8 @@ function getArtifactUrl(
 export function ArtifactImage({
   artifact,
   size,
-  thumb,
-  bgColor,
+  thumb: _thumb,
+  bgColor: _bgColor,
 }: {
   artifact: Artifact;
   size: number;

--- a/packages/client/src/Frontend/Components/DisplayGasPrices.tsx
+++ b/packages/client/src/Frontend/Components/DisplayGasPrices.tsx
@@ -1,5 +1,4 @@
-import { GasPrices } from "@df/types";
-import React from "react";
+import type { GasPrices } from "@df/types";
 
 export function DisplayGasPrices({ gasPrices }: { gasPrices?: GasPrices }) {
   return (

--- a/packages/client/src/Frontend/Components/GameLandingPageComponents.tsx
+++ b/packages/client/src/Frontend/Components/GameLandingPageComponents.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useLayoutEffect } from "react";
+import React, { type Dispatch, type SetStateAction, useLayoutEffect } from "react";
 import styled, { css } from "styled-components";
 import dfstyles from "../Styles/dfstyles";
 import UIEmitter, { UIEmitterEvent } from "../Utils/UIEmitter";

--- a/packages/client/src/Frontend/Components/Icons.tsx
+++ b/packages/client/src/Frontend/Components/Icons.tsx
@@ -1,5 +1,5 @@
 // should be able to be treated as a text element
-import { Planet, UpgradeBranchName } from "@df/types";
+import { type Planet, UpgradeBranchName } from "@df/types";
 import { DarkForestIcon, IconType } from "@df/ui";
 import { createComponent } from "@lit-labs/react";
 import React from "react";

--- a/packages/client/src/Frontend/Components/Labels/ArtifactLabels.tsx
+++ b/packages/client/src/Frontend/Components/Labels/ArtifactLabels.tsx
@@ -8,7 +8,7 @@ import {
   numToMemeType,
 } from "@df/procedural";
 import {
-  Artifact,
+  type Artifact,
   ArtifactRarity,
   ArtifactRarityNames,
   ArtifactType,
@@ -19,7 +19,6 @@ import {
   LogoTypeNames,
   MemeTypeNames,
 } from "@df/types";
-import React from "react";
 import styled from "styled-components";
 import { RarityColors } from "../../Styles/Colors";
 import { LegendaryLabel } from "./LegendaryLabel";

--- a/packages/client/src/Frontend/Components/Labels/BiomeLabels.tsx
+++ b/packages/client/src/Frontend/Components/Labels/BiomeLabels.tsx
@@ -1,12 +1,13 @@
 import { isAncient, isLocatable } from "@df/gamelogic";
-import {
+import type {
   Artifact,
-  Biome,
-  BiomeNames,
   LocatablePlanet,
   Planet,
 } from "@df/types";
-import React from "react";
+import {
+  Biome,
+  BiomeNames,
+} from "@df/types";
 import styled from "styled-components";
 import { BiomeTextColors } from "../../Styles/Colors";
 import { AncientLabel, AncientLabelAnim } from "../AncientLabel";
@@ -19,7 +20,7 @@ export const BiomeLabel = styled.span<{ biome: Biome }>`
   color: ${({ biome }) => BiomeTextColors[biome]};
 `;
 
-const StyledBiomeLabelAnim = styled(BiomeLabel)<{ biome: Biome }>`
+const StyledBiomeLabelAnim = styled(BiomeLabel) <{ biome: Biome }>`
   ${({ biome }) => biome === Biome.CORRUPTED && shakeAnim};
   ${({ biome }) => biome === Biome.ICE && icyAnim};
 `;

--- a/packages/client/src/Frontend/Components/LoadingSpinner.tsx
+++ b/packages/client/src/Frontend/Components/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import _, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 export function LoadingSpinner({
   initialText,

--- a/packages/client/src/Frontend/Components/RemoteModal.tsx
+++ b/packages/client/src/Frontend/Components/RemoteModal.tsx
@@ -1,4 +1,4 @@
-import { ModalId } from "@df/types";
+import type { ModalId } from "@df/types";
 import * as React from "react";
 import ReactDOM from "react-dom";
 // @ts-expect-error We need to add ModalPane code

--- a/packages/client/src/Frontend/Components/TimeUntil.tsx
+++ b/packages/client/src/Frontend/Components/TimeUntil.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Given a timestamp, displays the amount of time until the timestamp from now in hh:mm:ss format.

--- a/packages/client/src/Frontend/Pages/LandingPage.tsx
+++ b/packages/client/src/Frontend/Pages/LandingPage.tsx
@@ -1,6 +1,4 @@
-import { hello } from "utils";
 import { PLAYER_GUIDE } from "@df/constants";
-import { address } from "@df/serde";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { Link, Spacer, Title } from "../Components/CoreUI";
@@ -201,6 +199,7 @@ const SubTitle = styled.div`
   transform: translate(-50%, -50%);
 `;
 
+// @ts-ignore unused
 const PrettyOverlayGradient = styled.div`
   width: 100vw;
   height: 100vh;
@@ -222,11 +221,13 @@ const Header = styled.div`
   text-align: center;
 `;
 
+// @ts-ignore unused
 const EmailWrapper = styled.div`
   display: flex;
   flex-direction: row;
 `;
 
+// @ts-ignore unused
 const TRow = styled.tr`
   & td:first-child {
     color: ${dfstyles.colors.subtext};
@@ -268,6 +269,7 @@ const Page = styled.div`
   /* background-position: 1%; */
 `;
 
+// @ts-ignore unused
 const HallOfFameTitle = styled.div`
   color: ${dfstyles.colors.subtext};
   display: inline-block;
@@ -359,6 +361,7 @@ const OnlyMobile = styled.div`
   }
 `;
 
+// @ts-ignore unused
 const Involved = styled.div`
   width: 100%;
   padding-left: 16px;
@@ -373,6 +376,7 @@ const Involved = styled.div`
   }
 `;
 
+// @ts-ignore unused
 const InvolvedItem = styled.a`
   height: 150px;
   display: inline-block;
@@ -394,6 +398,7 @@ const InvolvedItem = styled.a`
   }
 `;
 
+// @ts-ignore unused
 const HallOfFame = styled.div`
   @media only screen and (max-device-width: 1000px) {
     font-size: 70%;

--- a/packages/client/src/Frontend/Styles/Mixins.tsx
+++ b/packages/client/src/Frontend/Styles/Mixins.tsx
@@ -1,5 +1,5 @@
 import { isLocatable } from "@df/gamelogic";
-import { Planet, PlanetType } from "@df/types";
+import { type Planet, PlanetType } from "@df/types";
 import { css, keyframes } from "styled-components";
 import { BiomeBackgroundColors } from "./Colors";
 

--- a/packages/client/src/Frontend/Views/CadetWormhole.tsx
+++ b/packages/client/src/Frontend/Views/CadetWormhole.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "styled-components";
 
 const CadetWormholeContainer = styled.div`

--- a/packages/client/src/PlanetTest/CreateMoveFormTest.tsx
+++ b/packages/client/src/PlanetTest/CreateMoveFormTest.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useMUD } from "@mud/MUDContext";
 
 interface CreateMoveProps {
   onSubmit: (

--- a/packages/client/src/PlanetTest/PlanetTestPage.tsx
+++ b/packages/client/src/PlanetTest/PlanetTestPage.tsx
@@ -1,4 +1,3 @@
-import { useMUD } from "@mud/MUDContext";
 import { CreatePlanetForm } from "./CreatePlanetFormTest";
 import { CreateMoveForm } from "./CreateMoveFormTest";
 import { PlayPauseButton } from "./PlayPauseButton";

--- a/packages/client/src/PlanetTest/PlayPauseButton.tsx
+++ b/packages/client/src/PlanetTest/PlayPauseButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useMUD } from "@mud/MUDContext";
 import { useComponentValue } from "@latticexyz/react";
 import { singletonEntity } from "@latticexyz/store-sync/recs";
@@ -46,8 +46,8 @@ export const PlayPauseButton = () => {
       <button
         onClick={handleToggle}
         className={`px-4 py-2 rounded-md text-white ${isPaused
-            ? "bg-green-500 hover:bg-green-600"
-            : "bg-red-500 hover:bg-red-600"
+          ? "bg-green-500 hover:bg-green-600"
+          : "bg-red-500 hover:bg-red-600"
           }`}
       >
         {isPaused ? "Play" : "Pause"}

--- a/packages/client/src/wallet/Components/SpawnPlayerPane.tsx
+++ b/packages/client/src/wallet/Components/SpawnPlayerPane.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useAccount } from "wagmi";
 import { useMUD } from "@mud/MUDContext";
 

--- a/packages/client/src/wallet/ExternalWalletProvider.tsx
+++ b/packages/client/src/wallet/ExternalWalletProvider.tsx
@@ -8,11 +8,11 @@ import {
   webSocket,
   http,
   getContract,
-  Hex,
-  ClientConfig,
+  type Hex,
+  type ClientConfig,
 } from "viem";
 import { useWalletClient } from "wagmi";
-import { NetworkConfig } from "@mud/getNetworkConfig";
+import type { NetworkConfig } from "@mud/getNetworkConfig";
 import { useStore } from "@hooks/useStore";
 
 export type Props = {

--- a/packages/client/src/wallet/WalletButton.tsx
+++ b/packages/client/src/wallet/WalletButton.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { CustomConnectButton } from "@wallet/CustomConnectButton";
 import { useAccount, useDisconnect, useWalletClient } from "wagmi";
 import { formatAddress } from "./utils";
 import { getNetworkConfig } from "@mud/getNetworkConfig";

--- a/packages/client/src/wallet/WalletPane.tsx
+++ b/packages/client/src/wallet/WalletPane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useWalletClient } from "wagmi";
 import { useBurnerBalance, useMainWalletBalance } from "@hooks/useBalance";
 import {
@@ -6,7 +6,7 @@ import {
   LOW_BALANCE_THRESHOLD,
   zeroAddress,
 } from "@wallet/utils";
-import { formatEther, parseEther, Hex } from "viem";
+import { formatEther, parseEther, type Hex } from "viem";
 import { useMUD } from "@mud/MUDContext";
 import { Btn } from "@frontend/Components/Btn";
 import { Modal } from "@frontend/Components/Modal";


### PR DESCRIPTION
what the title says ☝🏽 , from react TS >= 4.1 and React >= 17 with the new jsx transfrm, one does not need to import the React from JSX or TSX files, unless React is directly used.

## References
- [Introducing the new JSX Transform - ESlint](https://ru.legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.htm)
- [TS 4.1 - React 17 JSX Factories](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/)
- [TS Doc - Handbook](https://www.typescriptlang.org/docs/handbook/jsx.html)
