### PR TITLE
Client: remove dependency on lodash

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,7 +41,6 @@
     "fastq": "1.17.1",
     "gl-matrix": "3.4.3",
     "lit": "2.1.2",
-    "lodash": "4.17.15",
     "mnemonist": "0.39.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/client/src/Backend/Miner/MinerManager.ts
+++ b/packages/client/src/Backend/Miner/MinerManager.ts
@@ -1,7 +1,6 @@
 import { perlin } from "@df/hashing";
 import type { Chunk, PerlinConfig, Rectangle } from "@df/types";
 import { EventEmitter } from "events";
-import _ from "lodash";
 import type { ChunkStore } from "../../_types/darkforest/api/ChunkStoreTypes";
 import type {
   HashConfig,
@@ -19,6 +18,9 @@ export type workerFactory = () => Worker;
 function defaultWorker() {
   return new Worker(new URL("./miner.worker.ts", import.meta.url));
 }
+
+const range = (size: number) =>
+    [...new Array(size)].map((_, index) => index);
 
 export class HomePlanetMinerChunkStore implements ChunkStore {
   private initPerlinMin: number;
@@ -150,7 +152,10 @@ class MinerManager extends EventEmitter {
       useMockHash,
       workerFactory,
     );
-    _.range(minerManager.cores).forEach((i) => minerManager.initWorker(i));
+
+    for (const index of range(minerManager.cores)) {
+      minerManager.initWorker(index);
+    }
 
     return minerManager;
   }
@@ -232,7 +237,9 @@ class MinerManager extends EventEmitter {
       this.cores = nCores;
     }
 
-    _.range(this.cores).forEach((i) => this.initWorker(i));
+    for(const index of range(this.cores)) {
+      this.initWorker(index);
+    }
 
     if (wasMining) {
       this.startExplore();

--- a/packages/client/src/Shared/whitelist/index.ts
+++ b/packages/client/src/Shared/whitelist/index.ts
@@ -25,24 +25,25 @@
 import { mimcSponge } from "@df/hashing";
 import bigInt from "big-integer";
 import { ethers } from "ethers";
-import { chunk, padStart, replace } from "lodash";
 
 export const keysPerTx = 400;
 
-export const generateKey = () => {
-  const hexArray = padStart(
+export function generateKey() {
+  // generate 24 characters hex value
+  const hexValue = 
     bigInt(
       ethers.BigNumber.from(ethers.utils.randomBytes(12)).toString(),
-    ).toString(16),
-    24,
-    "0",
-  ).split("");
+    ).toString(16).padStart(24, '0');
 
-  return chunk(hexArray, 6)
-    .map((s) => s.join(""))
-    .join("-")
+  // split 24 character hex value into 4 words of 6 chars length
+  const words = Array.from(hexValue.matchAll(/(.{6})/g))
+    .map(([match]) => match);
+  
+  // return uppercased key on the form e.g. 862C58-D02664-2BC1F8-FD3CDF
+  return words
+    .join('-')
     .toUpperCase();
-};
+}
 
 export const generateKeys = (count: number) => {
   const keys = [] as string[];
@@ -54,7 +55,7 @@ export const generateKeys = (count: number) => {
 };
 
 export const bigIntFromKey = (key: string) =>
-  bigInt(replace(key, /\-/g, ""), 16);
+  bigInt(key.replaceAll('-', ''), 16);
 
 export const keyHash = (key: string) =>
   mimcSponge([bigIntFromKey(key)], 1, 220, 0)[0].toString();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,9 +134,6 @@ importers:
       lit:
         specifier: 2.1.2
         version: 2.1.2
-      lodash:
-        specifier: 4.17.15
-        version: 4.17.15
       mnemonist:
         specifier: 0.39.8
         version: 0.39.8
@@ -5465,9 +5462,6 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
-  lodash@4.17.15:
-    resolution: {integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==}
-
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -10312,7 +10306,7 @@ snapshots:
 
   '@metamask/safe-event-emitter@3.1.1': {}
 
-  '@metamask/sdk-communication-layer@0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5)':
+  '@metamask/sdk-communication-layer@0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       bufferutil: 4.0.8
       cross-fetch: 4.0.0
@@ -10348,7 +10342,7 @@ snapshots:
     dependencies:
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
-      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5)
+      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@metamask/sdk-install-modal-web': 0.26.5(i18next@23.11.5)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.22)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10))(react@18.2.0)
       '@types/dom-screen-wake-lock': 1.0.3
       bowser: 2.11.0
@@ -10383,7 +10377,7 @@ snapshots:
     dependencies:
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 16.1.0
-      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5)
+      '@metamask/sdk-communication-layer': 0.27.0(cross-fetch@4.0.0)(eciesjs@0.3.20)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@metamask/sdk-install-modal-web': 0.26.5(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/dom-screen-wake-lock': 1.0.3
       bowser: 2.11.0
@@ -14887,7 +14881,7 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isows@1.0.4(ws@8.17.1):
+  isows@1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
@@ -15259,8 +15253,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
-
-  lodash@4.17.15: {}
 
   lodash@4.17.21: {}
 
@@ -17392,7 +17384,7 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
       abitype: 1.0.5(typescript@5.4.2)(zod@3.23.8)
-      isows: 1.0.4(ws@8.17.1)
+      isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       webauthn-p256: 0.0.5
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:


### PR DESCRIPTION
No need to use lodash for these purposes:

1. The lodash `_.replace` was replaced with `String.replaceAll()` that is widely supported these days
2. The lodash `_.range` was replaced with a custom range function 
3. The lodash `_.chunk` was replaced with custom code that does the same


## Custom Range 

```ts
const range = (size: number, step = 1) =>
    [...new Array(size)].map((_, index) => index - step);
```

![Screenshot 2024-09-09 at 21 24 26](https://github.com/user-attachments/assets/67dc27fa-9c62-4a15-99e9-cad4003d84ac)

## Custom Chunk
```ts
Array.from(hexValue.matchAll(/(.{1,6})/g))
    .map(([match]) => match)
    .join('-')
    .toUpperCase();
```
![Screenshot 2024-09-09 at 21 34 06](https://github.com/user-attachments/assets/537ed692-9f90-491d-8291-5fbd870d5ec5)

