### PR TITLE
Update .eslintrc.cjs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -74,7 +74,7 @@ module.exports = {
     // ],
 
     // "no-only-tests/no-only-tests": "error",
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error",
+    "simple-import-sort/imports": "warn",
+    "simple-import-sort/exports": "warn",
   },
 };


### PR DESCRIPTION
Warn only on sort order, TypeScript already yields error on type error when used as type only 