### PR TITLE
chore: bump husky to v9 and fix eslint + format

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx commitlint --edit "$1"
+commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+lint-staged

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "mud:up": "pnpm mud set-version --tag main && pnpm install",
-    "prepare": "(forge --version || pnpm foundry:up) && husky install",
-    "format": "prettier --write '{packages}/**/*'",
+    "format": "prettier --write 'packages/**/*'",
     "lint": "pnpm --recursive run lint",
-    "lint:eslint": "pnpm --recursive run lint:eslint",
-    "lint:typecheck": "pnpm --recursive run lint:typecheck",
-    "test": "pnpm recursive run test"
+    "lint-fix": "pnpm --recursive run lint-fix",
+    "test": "pnpm recursive run test",
+    "preinstall": "npx only-allow pnpm",
+    "prepare": "(forge --version || pnpm foundry:up) && husky"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",
@@ -31,7 +31,7 @@
     "eslint-plugin-import": "2.30.0",
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-simple-import-sort": "12.1.1",
-    "husky": "8.0.3",
+    "husky": "9.1.5",
     "lint-staged": "15.2.10",
     "mprocs": "0.6.4",
     "rimraf": "6.0.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,8 +10,10 @@
     "format": "prettier --write .",
     "preview": "vite preview",
     "test": "echo 'tests not implemented'",
-    "lint": "pnpm run lint:eslint && pnpm run lint:typecheck",
+    "lint": "pnpm lint:eslint && pnpm lint:typecheck",
     "lint:eslint": "eslint --ext .js,.ts,tsx,.json src",
+    "lint-fix": "pnpm lint-fix:eslint",
+    "lint-fix:eslint": "pnpm lint:eslint --fix",
     "lint:typecheck": "tsc"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 12.1.1
         version: 12.1.1(eslint@8.57.0)
       husky:
-        specifier: 8.0.3
-        version: 8.0.3
+        specifier: 9.1.5
+        version: 9.1.5
       lint-staged:
         specifier: 15.2.10
         version: 15.2.10
@@ -5237,9 +5237,9 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
-  husky@8.0.3:
-    resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
-    engines: {node: '>=14'}
+  husky@9.1.5:
+    resolution: {integrity: sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==}
+    engines: {node: '>=18'}
     hasBin: true
 
   i18next-browser-languagedetector@7.1.0:
@@ -15315,7 +15315,7 @@ snapshots:
 
   human-signals@5.0.0: {}
 
-  husky@8.0.3: {}
+  husky@9.1.5: {}
 
   i18next-browser-languagedetector@7.1.0:
     dependencies:
@@ -15569,7 +15569,7 @@ snapshots:
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -15650,7 +15650,7 @@ snapshots:
       chalk: 4.1.2
       flow-parser: 0.245.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       neo-async: 2.6.2
       node-dir: 0.1.17
       recast: 0.21.5
@@ -16047,7 +16047,7 @@ snapshots:
       graceful-fs: 4.2.11
       invariant: 2.2.4
       jest-worker: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       node-abort-controller: 3.1.1
       nullthrows: 1.1.1
       walker: 1.0.8


### PR DESCRIPTION
1. Bumps husky to v9
2. Eslint fix
3. The format command was wrong was using glob pattern `{packages}/**/*` when it should have been `packages/**/*` , if we want to match multiple directories e.g. packages and apps we would hav needed glob `{app,packages}/**/*`.


## Husky v9
1. With husky v9, we only need to run `husky` without `install`
2. We also no longer need to use `npx` from commit-msg and pre-commit since it fixes the path.

## Eslint Fix
Adds the script command `lint-fix:eslint` e.g.: 👇 
<img width="1022" alt="Screenshot 2024-09-10 at 22 35 14" src="https://github.com/user-attachments/assets/5d26415c-582d-484a-b4a8-36c7f76315e8">

Will try to fix all eslint errors and warnings that are possible to autofix 👍 .

Can also be run from root via `pnpm lint-fix` or `pnpm --filter client lint-fix:eslint`
