### PR TITLE
fix: eslint and typescript issues

### DIFF
--- a/packages/client/src/Frontend/Components/BrowserIssues.tsx
+++ b/packages/client/src/Frontend/Components/BrowserIssues.tsx
@@ -1,4 +1,4 @@
-import type { Incompatibility } from "@frontend/Utils/BrowserChecks";
+import { Incompatibility } from "@frontend/Utils/BrowserChecks";
 import styled from "styled-components";
 
 const BrowserIssue = styled.p`

--- a/packages/client/src/Frontend/Pages/GameLandingPage.tsx
+++ b/packages/client/src/Frontend/Pages/GameLandingPage.tsx
@@ -1,28 +1,28 @@
-import type { GameManager } from "@backend/GameLogic/GameManager";
-import type { GameUIManager } from "@backend/GameLogic/GameUIManager";
+// import type { GameManager } from "@backend/GameLogic/GameManager";
+// import type { GameUIManager } from "@backend/GameLogic/GameUIManager";
 import {
-  BLOCK_EXPLORER_URL,
-  BLOCKCHAIN_BRIDGE,
-  HOW_TO_ENABLE_POPUPS,
-  HOW_TO_TRANSFER_ETH_FROM_L2_TO_REDSTONE,
+  // BLOCK_EXPLORER_URL,
+  // BLOCKCHAIN_BRIDGE,
+  // HOW_TO_ENABLE_POPUPS,
+  // HOW_TO_TRANSFER_ETH_FROM_L2_TO_REDSTONE,
   PLAYER_GUIDE,
-  TOKEN_NAME,
+  // TOKEN_NAME,
 } from "@df/constants";
 import {
   type BrowserCompatibleState,
   BrowserIssues,
 } from "@frontend/Components/BrowserIssues";
 import {
-  GameWindowWrapper,
+  // GameWindowWrapper,
   InitRenderState,
-  TerminalToggler,
+  // TerminalToggler,
   TerminalWrapper,
   Wrapper,
 } from "@frontend/Components/GameLandingPageComponents";
-import {
-  TopLevelDivProvider,
-  UIManagerProvider,
-} from "@frontend/Utils/AppHooks";
+// import {
+//   TopLevelDivProvider,
+//   UIManagerProvider,
+// } from "@frontend/Utils/AppHooks";
 import {
   type Incompatibility,
   unsupportedFeatures,
@@ -84,19 +84,25 @@ export function GameLandingPage() {
   const terminalHandle = useRef<TerminalHandle>(null);
   // const miniMapRef = useRef<MiniMapHandle>();
 
-  const [gameManager, setGameManager] = useState<GameManager | undefined>();
-  const gameUIManagerRef = useRef<GameUIManager | undefined>();
+  // const [gameManager, setGameManager] = useState<GameManager | undefined>();
+  // const gameUIManagerRef = useRef<GameUIManager | undefined>();
 
-  const [terminalVisible, setTerminalVisible] = useState(true);
-  const [initRenderState, setInitRenderState] = useState(InitRenderState.NONE);
+  const [
+    terminalVisible,
+    // setTerminalVisible
+  ] = useState(true);
+  const [
+    initRenderState,
+    // setInitRenderState
+  ] = useState(InitRenderState.NONE);
   const [step, setStep] = useState(TerminalPromptStep.NONE);
 
   const [browserCompatibleState, setBrowserCompatibleState] =
     useState<BrowserCompatibleState>("unknown");
 
   const [browserIssues, setBrowserIssues] = useState<Incompatibility[]>([]);
-  const [isMiniMapOn, setMiniMapOn] = useState(false);
-  const [spectate, setSpectate] = useState(false);
+  // const [isMiniMapOn, setMiniMapOn] = useState(false);
+  // const [spectate, setSpectate] = useState(false);
 
   useEffect(() => {
     unsupportedFeatures().then((issues) => {
@@ -206,7 +212,7 @@ export function GameLandingPage() {
         }
       }
     },
-    [],
+    [mainAccount],
   );
 
   const advanceState = useCallback(

--- a/packages/client/src/_types/global/GlobalTypes.ts
+++ b/packages/client/src/_types/global/GlobalTypes.ts
@@ -1,8 +1,7 @@
+import type { GameManager } from "@backend/GameLogic/GameManager";
+import type { GameUIManager } from "@backend/GameLogic/GameUIManager";
 import type { Rectangle } from "@df/types";
 import type { Dispatch, SetStateAction } from "react";
-
-import type GameManager from "../../Backend/GameLogic/GameManager";
-import type GameUIManager from "../../Backend/GameLogic/GameUIManager";
 
 export type Hook<T> = [T, Dispatch<SetStateAction<T>>];
 


### PR DESCRIPTION
What's done here 

## Eslint Fixes

Ran `pnpm lint:eslint --fix` first from the `packages/client` directory 👇 :
<img width="1072" alt="Screenshot 2024-09-10 at 22 49 10" src="https://github.com/user-attachments/assets/2516d06d-f244-4f04-b736-41663a6a1fa0">

Which autofixed what it could.

## TypeScript fixes

Ran `pnpm lint:typecheck` from the `packages/client` directory 👇 :
<img width="479" alt="Screenshot 2024-09-10 at 22 50 40" src="https://github.com/user-attachments/assets/0ee3de49-8fac-4669-b933-e75298a4fa7e">

Found 22 errors ☝️ , and fixed them manually.
