### PR TITLE
fix: codeowners should be dev not admin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dfarchon/df-mud-admin
+* @dfarchon/df-mud-dev


### PR DESCRIPTION
This reverts the change in #38, the code owners should be the dev group not admin.
Just to be clear here:

1. That a group is set in the Codeowners file does not mean they own the repo or anything. This jus means who should get a PR assignment notification.
2. The df-admin group is now only @cherryblue1024 and @ClaudeZsb , they have super admin rights that can bypass anything and that was what we agreed on.

From the docs [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners):
>Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests. For more information about draft pull requests, see "[About pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests)." When you mark a draft pull request as ready for review, code owners are automatically notified. If you convert a pull request to a draft, people who are already subscribed to notifications are not automatically unsubscribed. For more information, see "[Changing the stage of a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)."
