### PR TITLE
fix: eslint enforce curly

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,7 +20,7 @@ module.exports = {
     "plugin:prettier/recommended",
   ],
   rules: {
-    // curly: 2,
+    curly: 2,
     "no-restricted-globals": ["error", "history", "location", "name"],
     // "no-nested-ternary": "error",
     // "max-params": ["error", 4],

--- a/packages/client/src/Backend/GameLogic/ContractsAPI.ts
+++ b/packages/client/src/Backend/GameLogic/ContractsAPI.ts
@@ -159,7 +159,9 @@ export class ContractsAPI extends EventEmitter {
     overrides?: providers.TransactionRequest,
   ): Promise<void> {
     const address = this.ethConnection.getAddress();
-    if (!address) throw new Error("can't send a transaction, no signer");
+    if (!address) {
+      throw new Error("can't send a transaction, no signer");
+    }
 
     const balance = await this.ethConnection.loadBalance(address);
 
@@ -620,7 +622,9 @@ export class ContractsAPI extends EventEmitter {
   async getScoreV3(
     address: EthAddress | undefined,
   ): Promise<number | undefined> {
-    if (address === undefined) return undefined;
+    if (address === undefined) {
+      return undefined;
+    }
 
     const score = await this.makeCall<EthersBN>(this.contract.getScore, [
       address,
@@ -1171,7 +1175,9 @@ export class ContractsAPI extends EventEmitter {
     );
 
     const scoreFromBlockchain = await this.getScoreV3(playerId);
-    if (!rawPlayer.isInitialized) return undefined;
+    if (!rawPlayer.isInitialized) {
+      return undefined;
+    }
 
     const player = decodePlayer(rawPlayer);
     player.lastClaimTimestamp = lastClaimedTimestamp.toNumber();
@@ -1505,7 +1511,9 @@ export class ContractsAPI extends EventEmitter {
       this.contract.doesArtifactExist,
       [artifactIdToDecStr(artifactId)],
     );
-    if (!exists) return undefined;
+    if (!exists) {
+      return undefined;
+    }
     const rawArtifact = await this.makeCall(this.contract.getArtifactById, [
       artifactIdToDecStr(artifactId),
     ]);
@@ -1558,7 +1566,9 @@ export class ContractsAPI extends EventEmitter {
     playerId?: EthAddress,
     onProgress?: (percent: number) => void,
   ): Promise<Artifact[]> {
-    if (playerId === undefined) return [];
+    if (playerId === undefined) {
+      return [];
+    }
 
     const mySpacespaceIds = (
       await this.makeCall(this.contract.getPlayerArtifactIds, [playerId])
@@ -1570,7 +1580,9 @@ export class ContractsAPI extends EventEmitter {
     playerId?: EthAddress,
     onProgress?: (percent: number) => void,
   ): Promise<Artifact[]> {
-    if (playerId === undefined) return [];
+    if (playerId === undefined) {
+      return [];
+    }
 
     const myArtifactIds = (
       await this.makeCall<EthersBN[]>(this.contract.getMySpaceshipIds, [

--- a/packages/client/src/Backend/GameLogic/GameManager.ts
+++ b/packages/client/src/Backend/GameLogic/GameManager.ts
@@ -710,12 +710,24 @@ export class GameManager extends EventEmitter {
 
         const knownScoringPlanets = [];
         for (const planet of this.getAllPlanets()) {
-          if (!isLocatable(planet)) continue;
-          if (planet.destroyed || planet.frozen) continue;
-          if (planet.planetLevel < 3) continue;
-          if (!planet?.location?.coords) continue;
-          if (planet.claimer === EMPTY_ADDRESS) continue;
-          if (planet.claimer === undefined) continue;
+          if (!isLocatable(planet)) {
+            continue;
+          }
+          if (planet.destroyed || planet.frozen) {
+            continue;
+          }
+          if (planet.planetLevel < 3) {
+            continue;
+          }
+          if (!planet?.location?.coords) {
+            continue;
+          }
+          if (planet.claimer === EMPTY_ADDRESS) {
+            continue;
+          }
+          if (planet.claimer === undefined) {
+            continue;
+          }
           knownScoringPlanets.push({
             locationId: planet.locationId,
             claimer: planet.claimer,
@@ -733,9 +745,13 @@ export class GameManager extends EventEmitter {
 
         for (const planet of knownScoringPlanets) {
           const claimer = planet.claimer;
-          if (claimer === undefined) continue;
+          if (claimer === undefined) {
+            continue;
+          }
           const player = this.players.get(claimer);
-          if (player === undefined) continue;
+          if (player === undefined) {
+            continue;
+          }
 
           const cnt = cntMap.get(claimer);
           let cntNextValue = undefined;
@@ -759,7 +775,9 @@ export class GameManager extends EventEmitter {
           const result = haveScorePlayersMap.get(playerItem.address);
 
           const player = this.players.get(playerItem.address);
-          if (player === undefined) continue;
+          if (player === undefined) {
+            continue;
+          }
 
           if (result === false || result === undefined) {
             player.score = undefined;
@@ -1043,7 +1061,9 @@ export class GameManager extends EventEmitter {
         gameManager.onTxSubmit(tx);
       })
       .on(ContractsAPIEvent.TxConfirmed, async (tx: Transaction) => {
-        if (!tx.hash) return; // this should never happen
+        if (!tx.hash) {
+          return;
+        } // this should never happen
         gameManager.persistentChunkStore.onEthTxComplete(tx.hash);
 
         if (isUnconfirmedRevealTx(tx)) {
@@ -1269,9 +1289,13 @@ export class GameManager extends EventEmitter {
   }
 
   private async hardRefreshPlayer(address?: EthAddress): Promise<void> {
-    if (!address) return;
+    if (!address) {
+      return;
+    }
     const playerFromBlockchain = await this.contractsAPI.getPlayerById(address);
-    if (!playerFromBlockchain) return;
+    if (!playerFromBlockchain) {
+      return;
+    }
 
     const localPlayer = this.getPlayer(address);
 
@@ -1287,9 +1311,13 @@ export class GameManager extends EventEmitter {
     address?: EthAddress,
     show?: boolean,
   ): Promise<void> {
-    if (!address) return;
+    if (!address) {
+      return;
+    }
     const spaceships = await this.contractsAPI.getPlayerSpaceships(address);
-    if (show) console.log(spaceships.length);
+    if (show) {
+      console.log(spaceships.length);
+    }
     for (let i = 0; i < spaceships.length; i++) {
       if (show) {
         console.log("--- spaceship ", i, " ---");
@@ -1302,7 +1330,9 @@ export class GameManager extends EventEmitter {
 
       if (voyageId !== undefined) {
         const arrival = await this.contractsAPI.getArrival(Number(voyageId));
-        if (show) console.log("voyageId:", voyageId);
+        if (show) {
+          console.log("voyageId:", voyageId);
+        }
         // console.log(arrival);
         if (arrival) {
           const fromPlanet = arrival.fromPlanet;
@@ -1315,7 +1345,9 @@ export class GameManager extends EventEmitter {
             this.hardRefreshPlanet(fromPlanet),
             this.hardRefreshPlanet(toPlanet),
           ]);
-          if (show) console.log("[OK] finish hard refresh from & to planets");
+          if (show) {
+            console.log("[OK] finish hard refresh from & to planets");
+          }
         }
       }
     }
@@ -1334,13 +1366,17 @@ export class GameManager extends EventEmitter {
   // Dirty hack for only refreshing properties on a planet and nothing else
   public async softRefreshPlanet(planetId: LocationId): Promise<void> {
     const planet = await this.contractsAPI.getPlanetById(planetId);
-    if (!planet) return;
+    if (!planet) {
+      return;
+    }
     this.entityStore.replacePlanetFromContractData(planet);
   }
 
   public async hardRefreshPlanet(planetId: LocationId): Promise<void> {
     const planet = await this.contractsAPI.getPlanetById(planetId);
-    if (!planet) return;
+    if (!planet) {
+      return;
+    }
     const arrivals = await this.contractsAPI.getArrivalsForPlanet(planetId);
 
     const artifactsOnPlanets =
@@ -1478,7 +1514,9 @@ export class GameManager extends EventEmitter {
 
   public async hardRefreshArtifact(artifactId: ArtifactId): Promise<void> {
     const artifact = await this.contractsAPI.getArtifactById(artifactId);
-    if (!artifact) return;
+    if (!artifact) {
+      return;
+    }
     this.entityStore.replaceArtifactFromContractData(artifact);
   }
 
@@ -1490,7 +1528,9 @@ export class GameManager extends EventEmitter {
     for (const item of loadedBurnedCoords) {
       const locationId = item.hash;
       const planet = this.getPlanetWithId(locationId);
-      if (planet === undefined) continue;
+      if (planet === undefined) {
+        continue;
+      }
 
       const burnedLocation = {
         ...this.locationFromCoords(item),
@@ -1513,7 +1553,9 @@ export class GameManager extends EventEmitter {
     for (const item of loadedKardashevCoords) {
       const locationId = item.hash;
       const planet = this.getPlanetWithId(locationId);
-      if (planet === undefined) continue;
+      if (planet === undefined) {
+        continue;
+      }
 
       const kardashevLocation = {
         ...this.locationFromCoords(item),
@@ -1618,8 +1660,11 @@ export class GameManager extends EventEmitter {
    */
   public getTwitter(address: EthAddress | undefined): string | undefined {
     let myAddress;
-    if (!address) myAddress = this.getAccount();
-    else myAddress = address;
+    if (!address) {
+      myAddress = this.getAccount();
+    } else {
+      myAddress = address;
+    }
 
     if (!myAddress) {
       return undefined;
@@ -1803,8 +1848,12 @@ export class GameManager extends EventEmitter {
 
   public getPlayerScore(addr: EthAddress): number | undefined {
     const player = this.players.get(addr);
-    if (!player) return undefined;
-    if (player.lastClaimTimestamp === 0) return undefined;
+    if (!player) {
+      return undefined;
+    }
+    if (player.lastClaimTimestamp === 0) {
+      return undefined;
+    }
     return player?.score;
   }
 
@@ -1837,7 +1886,9 @@ export class GameManager extends EventEmitter {
   }
 
   private initMiningManager(homeCoords: WorldCoords, cores?: number): void {
-    if (this.minerManager) return;
+    if (this.minerManager) {
+      return;
+    }
 
     const myPattern: MiningPattern = new SpiralPattern(
       homeCoords,
@@ -1891,8 +1942,11 @@ export class GameManager extends EventEmitter {
    * Gets the mining pattern that the miner is currently using.
    */
   getMiningPattern(): MiningPattern | undefined {
-    if (this.minerManager) return this.minerManager.getMiningPattern();
-    else return undefined;
+    if (this.minerManager) {
+      return this.minerManager.getMiningPattern();
+    } else {
+      return undefined;
+    }
   }
 
   /**
@@ -2016,7 +2070,9 @@ export class GameManager extends EventEmitter {
    * gets both deposited artifacts that are on planets i own as well as artifacts i own
    */
   getMyArtifacts(): Artifact[] {
-    if (!this.account) return [];
+    if (!this.account) {
+      return [];
+    }
     const ownedByMe = this.entityStore.getArtifactsOwnedBy(this.account);
     const onPlanetsOwnedByMe = this.entityStore
       .getArtifactsOnPlanetsOwnedBy(this.account)
@@ -2196,7 +2252,9 @@ export class GameManager extends EventEmitter {
    * Gets the balance of the account measured in Eth (i.e. in full units of the chain).
    */
   getMyBalanceEth(): number {
-    if (!this.account) return 0;
+    if (!this.account) {
+      return 0;
+    }
     return weiToEth(this.getMyBalance());
   }
 
@@ -2248,7 +2306,9 @@ export class GameManager extends EventEmitter {
    * Gets the location of your home planet.
    */
   getHomeCoords(): WorldCoords | undefined {
-    if (!this.homeLocation) return undefined;
+    if (!this.homeLocation) {
+      return undefined;
+    }
     return {
       x: this.homeLocation.coords.x,
       y: this.homeLocation.coords.y,
@@ -2353,7 +2413,9 @@ export class GameManager extends EventEmitter {
    * process by telling the Dark Forest webserver to look at that tweet.
    */
   async submitVerifyTwitter(twitter: string): Promise<boolean> {
-    if (!this.account) return Promise.resolve(false);
+    if (!this.account) {
+      return Promise.resolve(false);
+    }
     const success = await verifyTwitterHandle(
       await this.ethConnection.signMessageObject({ twitter }),
     );
@@ -2455,7 +2517,9 @@ export class GameManager extends EventEmitter {
       throw new Error("no account set");
     }
     const planet = this.getPlanetWithId(planetId);
-    if (!isLocatable(planet)) return 0;
+    if (!isLocatable(planet)) {
+      return 0;
+    }
     const myPinkZones = this.getMyPinkZones();
     let result = -1;
     for (const pinkZone of myPinkZones) {
@@ -2463,19 +2527,29 @@ export class GameManager extends EventEmitter {
       const coords = pinkZone.coords;
       const radius = pinkZone.radius;
       const burnPlanet = this.getPlanetWithId(burnPlanetId);
-      if (!burnPlanet) continue;
-      if (!burnPlanet.burnStartTimestamp) continue;
+      if (!burnPlanet) {
+        continue;
+      }
+      if (!burnPlanet.burnStartTimestamp) {
+        continue;
+      }
 
       const dis = this.getDistCoords(coords, planet.location.coords);
 
       if (dis <= radius) {
-        if (result === -1) result = burnPlanet.burnStartTimestamp;
-        else result = result = Math.min(result, burnPlanet.burnStartTimestamp);
+        if (result === -1) {
+          result = burnPlanet.burnStartTimestamp;
+        } else {
+          result = result = Math.min(result, burnPlanet.burnStartTimestamp);
+        }
       }
     }
 
-    if (result === 1) return 0;
-    else return (result + this.contractConstants.PINK_PLANET_COOLDOWN) * 1000;
+    if (result === 1) {
+      return 0;
+    } else {
+      return (result + this.contractConstants.PINK_PLANET_COOLDOWN) * 1000;
+    }
   }
 
   /**
@@ -2488,7 +2562,9 @@ export class GameManager extends EventEmitter {
       throw new Error("no account set");
     }
     const planet = this.getPlanetWithId(planetId);
-    if (!isLocatable(planet)) return undefined;
+    if (!isLocatable(planet)) {
+      return undefined;
+    }
     const myBlueZones = this.getMyBlueZones();
 
     for (const blueZone of myBlueZones) {
@@ -2496,8 +2572,12 @@ export class GameManager extends EventEmitter {
       const coords = blueZone.coords;
 
       const centerPlanet = this.getPlanetWithId(blueZoneCenterPlanetId);
-      if (!centerPlanet) continue;
-      if (!centerPlanet.kardashevTimestamp) continue;
+      if (!centerPlanet) {
+        continue;
+      }
+      if (!centerPlanet.kardashevTimestamp) {
+        continue;
+      }
       const distanceToZone = this.getDistCoords(coords, planet.location.coords);
       if (
         distanceToZone <=
@@ -2511,9 +2591,15 @@ export class GameManager extends EventEmitter {
           dis = distanceToZone;
         } else if (distanceToZone === dis) {
           const tmp = this.getPlanetWithId(centerPlanetId);
-          if (!tmp) continue;
-          if (!tmp.kardashevTimestamp) continue;
-          if (!centerPlanet.kardashevTimestamp) continue;
+          if (!tmp) {
+            continue;
+          }
+          if (!tmp.kardashevTimestamp) {
+            continue;
+          }
+          if (!centerPlanet.kardashevTimestamp) {
+            continue;
+          }
           if (tmp.kardashevTimestamp > centerPlanet.kardashevTimestamp) {
             centerPlanetId = centerPlanet.locationId;
             dis = distanceToZone;
@@ -2552,13 +2638,21 @@ export class GameManager extends EventEmitter {
       throw new Error("no account set");
     }
     const planet = this.getPlanetWithId(planetId);
-    if (!isLocatable(planet)) return 0;
+    if (!isLocatable(planet)) {
+      return 0;
+    }
 
     const centerPlanetId = this.getBlueZoneCenterPlanetId(planetId);
-    if (centerPlanetId === undefined) return 0;
+    if (centerPlanetId === undefined) {
+      return 0;
+    }
     const centerPlanet = this.getPlanetWithId(centerPlanetId);
-    if (!centerPlanet) return 0;
-    if (!centerPlanet.kardashevTimestamp) return 0;
+    if (!centerPlanet) {
+      return 0;
+    }
+    if (!centerPlanet.kardashevTimestamp) {
+      return 0;
+    }
     return (
       (centerPlanet.kardashevTimestamp +
         this.contractConstants.BLUE_PLANET_COOLDOWN) *
@@ -2629,7 +2723,9 @@ export class GameManager extends EventEmitter {
 
     for (const item of allBurnedLocationsValues) {
       const planet = this.getPlanetWithId(item.hash);
-      if (planet === undefined) continue;
+      if (planet === undefined) {
+        continue;
+      }
       const locationId = planet.locationId;
       const coords = { x: item.coords.x, y: item.coords.y };
       const operator = item.operator;
@@ -2656,8 +2752,12 @@ export class GameManager extends EventEmitter {
 
     for (const item of allBurnedLocationsValues) {
       const planet = this.getPlanetWithId(item.hash);
-      if (planet === undefined) continue;
-      if (planet.burnOperator !== this.account) continue;
+      if (planet === undefined) {
+        continue;
+      }
+      if (planet.burnOperator !== this.account) {
+        continue;
+      }
       const locationId = planet.locationId;
       const coords = { x: item.coords.x, y: item.coords.y };
       const operator = item.operator;
@@ -2684,7 +2784,9 @@ export class GameManager extends EventEmitter {
 
     for (const item of allKardashevLocationsValues) {
       const planet = this.getPlanetWithId(item.hash);
-      if (planet === undefined) continue;
+      if (planet === undefined) {
+        continue;
+      }
       const locationId = planet.locationId;
       const coords = { x: item.coords.x, y: item.coords.y };
       const operator = item.operator;
@@ -2709,8 +2811,12 @@ export class GameManager extends EventEmitter {
 
     for (const item of allKardashevLocationsValues) {
       const planet = this.getPlanetWithId(item.hash);
-      if (planet === undefined) continue;
-      if (planet.kardashevOperator !== this.account) continue;
+      if (planet === undefined) {
+        continue;
+      }
+      if (planet.kardashevOperator !== this.account) {
+        continue;
+      }
       const locationId = planet.locationId;
       const coords = { x: item.coords.x, y: item.coords.y };
       const operator = item.operator;
@@ -3058,10 +3164,16 @@ export class GameManager extends EventEmitter {
   }
 
   public checkPlanetCanPink(planetId: LocationId): boolean {
-    if (!this.account) return false;
+    if (!this.account) {
+      return false;
+    }
     const planet = this.getPlanetWithId(planetId);
-    if (!planet) return false;
-    if (!isLocatable(planet)) return false;
+    if (!planet) {
+      return false;
+    }
+    if (!isLocatable(planet)) {
+      return false;
+    }
     const myPinkZones = this.getMyPinkZones();
     for (const pinkZone of myPinkZones) {
       const coords = pinkZone.coords;
@@ -3069,7 +3181,9 @@ export class GameManager extends EventEmitter {
 
       const dis = this.getDistCoords(coords, planet.location.coords);
 
-      if (dis <= radius) return true;
+      if (dis <= radius) {
+        return true;
+      }
     }
     return false;
   }
@@ -3310,14 +3424,24 @@ export class GameManager extends EventEmitter {
   }
 
   public checkPlanetCanBlue(planetId: LocationId): boolean {
-    if (!this.account) return false;
+    if (!this.account) {
+      return false;
+    }
     const planet = this.getPlanetWithId(planetId);
-    if (!planet) return false;
-    if (!isLocatable(planet)) return false;
+    if (!planet) {
+      return false;
+    }
+    if (!isLocatable(planet)) {
+      return false;
+    }
     const centerPlanetId = this.getBlueZoneCenterPlanetId(planetId);
 
-    if (!centerPlanetId) return false;
-    if (centerPlanetId === planetId) return false;
+    if (!centerPlanetId) {
+      return false;
+    }
+    if (centerPlanetId === planetId) {
+      return false;
+    }
     return true;
   }
 
@@ -3706,7 +3830,9 @@ export class GameManager extends EventEmitter {
   }
   // mytodo: some player can't get spaceships, the homeLocation.hash is not right
   private async getSpaceships() {
-    if (!this.account) return;
+    if (!this.account) {
+      return;
+    }
     if (
       !Object.values(this.contractConstants.SPACESHIPS).some((a) => a === true)
     ) {
@@ -3715,10 +3841,16 @@ export class GameManager extends EventEmitter {
     }
 
     const player = await this.contractsAPI.getPlayerById(this.account);
-    if (!player) return;
-    if (player?.claimedShips) return;
+    if (!player) {
+      return;
+    }
+    if (player?.claimedShips) {
+      return;
+    }
 
-    if (this.getGameObjects().isGettingSpaceships()) return;
+    if (this.getGameObjects().isGettingSpaceships()) {
+      return;
+    }
 
     const homePlanetLocationId = "0x" + player.homePlanetId;
 
@@ -4014,7 +4146,9 @@ export class GameManager extends EventEmitter {
       }
 
       if (!bypassChecks) {
-        if (this.checkGameHasEnded()) throw new Error("game ended");
+        if (this.checkGameHasEnded()) {
+          throw new Error("game ended");
+        }
 
         if (!planet) {
           throw new Error("you can't prospect a planet you haven't discovered");
@@ -4150,7 +4284,9 @@ export class GameManager extends EventEmitter {
                 ) as Artifact;
             },
           ).then((foundArtifact) => {
-            if (!foundArtifact) throw new Error("Artifact not found?");
+            if (!foundArtifact) {
+              throw new Error("Artifact not found?");
+            }
             const notifManager = NotificationManager.getInstance();
 
             notifManager.artifactFound(
@@ -4524,12 +4660,24 @@ export class GameManager extends EventEmitter {
       // eslint-disable-next-line no-inner-declarations
       function isTypeOK() {
         const val = Number(type);
-        if (val === Number(ArtifactType.Wormhole)) return true;
-        if (val === Number(ArtifactType.PlanetaryShield)) return true;
-        if (val === Number(ArtifactType.BloomFilter)) return true;
-        if (val === Number(ArtifactType.FireLink)) return true;
-        if (val === Number(ArtifactType.StellarShield)) return true;
-        if (val === Number(ArtifactType.Avatar)) return true;
+        if (val === Number(ArtifactType.Wormhole)) {
+          return true;
+        }
+        if (val === Number(ArtifactType.PlanetaryShield)) {
+          return true;
+        }
+        if (val === Number(ArtifactType.BloomFilter)) {
+          return true;
+        }
+        if (val === Number(ArtifactType.FireLink)) {
+          return true;
+        }
+        if (val === Number(ArtifactType.StellarShield)) {
+          return true;
+        }
+        if (val === Number(ArtifactType.Avatar)) {
+          return true;
+        }
 
         return false;
       }
@@ -4540,8 +4688,12 @@ export class GameManager extends EventEmitter {
         const rarityVal = parseInt(rarity.toString());
         const typeVal = parseInt(type.toString());
 
-        if (rarityVal === 0 || rarityVal >= 5) return 0;
-        if (isTypeOK() === false) return 0;
+        if (rarityVal === 0 || rarityVal >= 5) {
+          return 0;
+        }
+        if (isTypeOK() === false) {
+          return 0;
+        }
         if (
           typeVal === Number(ArtifactType.Wormhole) ||
           typeVal === Number(ArtifactType.PlanetaryShield) ||
@@ -4553,7 +4705,9 @@ export class GameManager extends EventEmitter {
           return 1;
         } else if (typeVal === Number(ArtifactType.StellarShield)) {
           return 8;
-        } else return 0;
+        } else {
+          return 0;
+        }
       }
 
       //NOTE: this will not be the true artifactId
@@ -4608,7 +4762,9 @@ export class GameManager extends EventEmitter {
   ): Promise<Transaction<UnconfirmedWithdrawSilver>> {
     try {
       if (!bypassChecks) {
-        if (!this.account) throw new Error("no account");
+        if (!this.account) {
+          throw new Error("no account");
+        }
         // if (this.checkGameHasEnded()) {
         //   throw new Error('game has ended');
         // }
@@ -5113,7 +5269,9 @@ export class GameManager extends EventEmitter {
       // price requirements
       const balanceEth = this.getMyBalanceEth();
       let hatCostEth = planet.hatLevel === 0 ? 0.002 : 0;
-      if (halfPrice) hatCostEth *= 0.5;
+      if (halfPrice) {
+        hatCostEth *= 0.5;
+      }
 
       if (balanceEth < hatCostEth) {
         throw new Error("you don't have enough ETH");
@@ -5310,7 +5468,9 @@ export class GameManager extends EventEmitter {
 
       // 0.003 *(2**(num-1)) eth
       let fee = bigInt(3_000_000_000_000_000).multiply(fee_delete);
-      if (halfPrice) fee = bigInt(1_500_000_000_000_000).multiply(fee_delete);
+      if (halfPrice) {
+        fee = bigInt(1_500_000_000_000_000).multiply(fee_delete);
+      }
 
       const tx = await this.contractsAPI.submitTransaction(txIntent, {
         value: fee.toString(),
@@ -5393,7 +5553,9 @@ export class GameManager extends EventEmitter {
       };
 
       let fee = bigInt(1_000_000_000_000_000).toString(); //0.001 eth
-      if (halfPrice) fee = bigInt(500_000_000_000_000).toString();
+      if (halfPrice) {
+        fee = bigInt(500_000_000_000_000).toString();
+      }
 
       localStorage.setItem(
         `${this.getAccount()?.toLowerCase()}-buySpaceshipOnPlanetId`,
@@ -5623,7 +5785,9 @@ export class GameManager extends EventEmitter {
     abandoning: boolean,
   ): number {
     const planet = this.getPlanetWithId(planetId);
-    if (!planet) throw new Error("origin planet unknown");
+    if (!planet) {
+      throw new Error("origin planet unknown");
+    }
     return getRange(planet, sendingPercent, this.getRangeBuff(abandoning));
   }
 
@@ -5677,8 +5841,12 @@ export class GameManager extends EventEmitter {
     abandoning: boolean,
   ): Planet[] {
     const planet = this.entityStore.getPlanetWithId(planetId);
-    if (!planet) throw new Error("planet unknown");
-    if (!isLocatable(planet)) throw new Error("planet location unknown");
+    if (!planet) {
+      throw new Error("planet unknown");
+    }
+    if (!isLocatable(planet)) {
+      throw new Error("planet location unknown");
+    }
 
     // Performance improvements originally suggested by [@modokon](https://github.com/modukon)
     // at https://github.com/darkforest-eth/client/issues/15
@@ -5713,7 +5881,9 @@ export class GameManager extends EventEmitter {
     abandoning = false,
   ): number {
     const from = this.getPlanetWithId(fromId);
-    if (!from) throw new Error("origin planet unknown");
+    if (!from) {
+      throw new Error("origin planet unknown");
+    }
     const dist = this.getDist(fromId, toId);
     const range = from.range * this.getRangeBuff(abandoning);
     const rangeSteps = dist / range;
@@ -5738,9 +5908,12 @@ export class GameManager extends EventEmitter {
     const from = this.getPlanetWithId(fromId);
     const to = this.getPlanetWithId(toId);
 
-    if (!from) throw new Error(`unknown planet`);
-    if (distance === undefined && toId === undefined)
+    if (!from) {
+      throw new Error(`unknown planet`);
+    }
+    if (distance === undefined && toId === undefined) {
       throw new Error(`you must provide either a target planet or a distance`);
+    }
 
     const dist = (toId && this.getDist(fromId, toId)) || (distance as number);
 
@@ -5756,7 +5929,9 @@ export class GameManager extends EventEmitter {
     const range = from.range * this.getRangeBuff(abandoning);
     const scale = (1 / 2) ** (dist / range);
     let ret = scale * sentEnergy - 0.05 * from.energyCap;
-    if (ret < 0) ret = 0;
+    if (ret < 0) {
+      ret = 0;
+    }
 
     return ret;
   }

--- a/packages/client/src/Backend/GameLogic/GameObjects.ts
+++ b/packages/client/src/Backend/GameLogic/GameObjects.ts
@@ -439,7 +439,9 @@ export class GameObjects {
       return planet;
     }
     const loc = this.getLocationOfPlanet(planetId);
-    if (!loc) return undefined;
+    if (!loc) {
+      return undefined;
+    }
     return this.getPlanetWithLocation(loc);
   }
 
@@ -626,7 +628,9 @@ export class GameObjects {
   public getPlanetWithLocation(
     location: WorldLocation | undefined,
   ): Planet | undefined {
-    if (!location) return undefined;
+    if (!location) {
+      return undefined;
+    }
 
     const planet = this.planets.get(location.hash);
     if (planet) {
@@ -1482,16 +1486,27 @@ export class GameObjects {
       const MAX_LEVEL_DIST = this.contractConstants.MAX_LEVEL_DIST; //    [40000, 30000, 20000, 10000, 5000];
       const MAX_LEVEL_LIMIT = this.contractConstants.MAX_LEVEL_LIMIT.map(
         (x) => {
-          if (x === 1) return PlanetLevel.ONE;
-          else if (x === 2) return PlanetLevel.TWO;
-          else if (x === 3) return PlanetLevel.THREE;
-          else if (x === 4) return PlanetLevel.FOUR;
-          else if (x === 5) return PlanetLevel.FIVE;
-          else if (x === 6) return PlanetLevel.SIX;
-          else if (x === 7) return PlanetLevel.SEVEN;
-          else if (x === 8) return PlanetLevel.EIGHT;
-          else if (x === 9) return PlanetLevel.NINE;
-          else return PlanetLevel.ZERO;
+          if (x === 1) {
+            return PlanetLevel.ONE;
+          } else if (x === 2) {
+            return PlanetLevel.TWO;
+          } else if (x === 3) {
+            return PlanetLevel.THREE;
+          } else if (x === 4) {
+            return PlanetLevel.FOUR;
+          } else if (x === 5) {
+            return PlanetLevel.FIVE;
+          } else if (x === 6) {
+            return PlanetLevel.SIX;
+          } else if (x === 7) {
+            return PlanetLevel.SEVEN;
+          } else if (x === 8) {
+            return PlanetLevel.EIGHT;
+          } else if (x === 9) {
+            return PlanetLevel.NINE;
+          } else {
+            return PlanetLevel.ZERO;
+          }
         },
       );
 
@@ -1535,8 +1550,9 @@ export class GameObjects {
     if (
       distFromOrigin < MAX_LEVEL_DIST[0] &&
       distFromOrigin > MAX_LEVEL_DIST[1]
-    )
+    ) {
       return SpaceType.NEBULA;
+    }
 
     if (perlin < this.contractConstants.PERLIN_THRESHOLD_1) {
       return SpaceType.NEBULA;
@@ -1556,12 +1572,18 @@ export class GameObjects {
 
   public static planetCanUpgrade(planet: Planet): boolean {
     const totalRank = planet.upgradeState.reduce((a, b) => a + b);
-    if (planet.spaceType === SpaceType.NEBULA && totalRank >= 3) return false;
-    if (planet.spaceType === SpaceType.SPACE && totalRank >= 4) return false;
-    if (planet.spaceType === SpaceType.DEEP_SPACE && totalRank >= 5)
+    if (planet.spaceType === SpaceType.NEBULA && totalRank >= 3) {
       return false;
-    if (planet.spaceType === SpaceType.DEAD_SPACE && totalRank >= 5)
+    }
+    if (planet.spaceType === SpaceType.SPACE && totalRank >= 4) {
       return false;
+    }
+    if (planet.spaceType === SpaceType.DEEP_SPACE && totalRank >= 5) {
+      return false;
+    }
+    if (planet.spaceType === SpaceType.DEAD_SPACE && totalRank >= 5) {
+      return false;
+    }
     return (
       planet.planetLevel !== 0 &&
       planet.planetType === PlanetType.PLANET &&
@@ -1609,12 +1631,18 @@ export class GameObjects {
     const distFromOrigin = Math.floor(Math.sqrt(coords.x ** 2 + coords.y ** 2));
     const spaceType = this.spaceTypeFromPerlin(perlin, distFromOrigin);
 
-    if (spaceType === SpaceType.DEAD_SPACE) return Biome.CORRUPTED;
+    if (spaceType === SpaceType.DEAD_SPACE) {
+      return Biome.CORRUPTED;
+    }
 
     let biome = 3 * spaceType;
-    if (biomebase < this.contractConstants.BIOME_THRESHOLD_1) biome += 1;
-    else if (biomebase < this.contractConstants.BIOME_THRESHOLD_2) biome += 2;
-    else biome += 3;
+    if (biomebase < this.contractConstants.BIOME_THRESHOLD_1) {
+      biome += 1;
+    } else if (biomebase < this.contractConstants.BIOME_THRESHOLD_2) {
+      biome += 2;
+    } else {
+      biome += 3;
+    }
 
     return biome as Biome;
   }
@@ -1743,11 +1771,17 @@ export class GameObjects {
         this.contractConstants.defaultBarbarianPercentage[planetLevel]) /
       100;
     // increase pirates
-    if (spaceType === SpaceType.DEAD_SPACE) pirates *= 20;
-    else if (spaceType === SpaceType.DEEP_SPACE) pirates *= 10;
-    else if (spaceType === SpaceType.SPACE) pirates *= 4;
+    if (spaceType === SpaceType.DEAD_SPACE) {
+      pirates *= 20;
+    } else if (spaceType === SpaceType.DEEP_SPACE) {
+      pirates *= 10;
+    } else if (spaceType === SpaceType.SPACE) {
+      pirates *= 4;
+    }
 
-    if (planetType === PlanetType.SILVER_BANK) pirates /= 2;
+    if (planetType === PlanetType.SILVER_BANK) {
+      pirates /= 2;
+    }
 
     pirates = Math.floor(pirates);
 
@@ -1914,7 +1948,9 @@ export class GameObjects {
   public getArrivalIdsForLocation(
     location: LocationId | undefined,
   ): VoyageId[] | undefined {
-    if (!location) return [];
+    if (!location) {
+      return [];
+    }
 
     return this.planetArrivalIds.get(location);
   }

--- a/packages/client/src/Backend/GameLogic/GameUIManager.ts
+++ b/packages/client/src/Backend/GameLogic/GameUIManager.ts
@@ -432,7 +432,9 @@ export class GameUIManager extends EventEmitter {
       ` deactivation, you must wait for a long cooldown` +
       ` before you can activate it again. Some artifacts (bloom filter, black domain, photoid cannon, fire link) are consumed on usage.`;
 
-    if (!confirm(confirmationText)) return;
+    if (!confirm(confirmationText)) {
+      return;
+    }
 
     this.gameManager.activateArtifact(locationId, id, linkTo);
   }
@@ -447,7 +449,9 @@ export class GameUIManager extends EventEmitter {
       `After deactivation, you must wait for a long cooldown` +
       ` before you can activate it again. Some artifacts (planetary shield, ice link) are consumed on deactivation.`;
 
-    if (!confirm(confirmationText)) return;
+    if (!confirm(confirmationText)) {
+      return;
+    }
 
     this.gameManager.deactivateArtifact(locationId, artifactId, linkTo);
   }
@@ -484,7 +488,9 @@ export class GameUIManager extends EventEmitter {
       const confirmationText =
         `Are you sure you want withdraw this silver? Once you withdraw it, you ` +
         `cannot deposit it again. Your withdrawn silver amount will be added to your score. You'll only see this warning once!`;
-      if (!confirm(confirmationText)) return;
+      if (!confirm(confirmationText)) {
+        return;
+      }
     }
 
     this.gameManager.withdrawSilver(locationId, amount);
@@ -619,7 +625,9 @@ export class GameUIManager extends EventEmitter {
   }
 
   public onMouseDown(coords: WorldCoords) {
-    if (this.sendingPlanet) return;
+    if (this.sendingPlanet) {
+      return;
+    }
 
     const hoveringOverCoords = this.updateMouseHoveringOverCoords(coords);
     const hoveringOverPlanet =
@@ -698,7 +706,9 @@ export class GameUIManager extends EventEmitter {
           forces = 0;
         } else if (forces >= from.energy) {
           forces = from.energy - 1;
-          if (forces < 1) return;
+          if (forces < 1) {
+            return;
+          }
         }
 
         const dist = this.gameManager.getDist(from.locationId, to.locationId);
@@ -790,21 +800,31 @@ export class GameUIManager extends EventEmitter {
 
   public toggleTargettingExplorer() {
     const modalManager = this.modalManager;
-    if (modalManager.getCursorState() === CursorState.TargetingExplorer)
+    if (modalManager.getCursorState() === CursorState.TargetingExplorer) {
       modalManager.setCursorState(CursorState.Normal);
-    else modalManager.setCursorState(CursorState.TargetingExplorer);
+    } else {
+      modalManager.setCursorState(CursorState.TargetingExplorer);
+    }
   }
 
   public setForcesSending(planetId: LocationId, percentage: number) {
-    if (percentage < 0) percentage = 0;
-    if (percentage > 100) percentage = 100;
+    if (percentage < 0) {
+      percentage = 0;
+    }
+    if (percentage > 100) {
+      percentage = 100;
+    }
     this.forcesSending[planetId] = percentage;
     this.gameManager.getGameObjects().forceTick(planetId);
   }
 
   public setSilverSending(planetId: LocationId, percentage: number) {
-    if (percentage < 0) percentage = 0;
-    if (percentage > 100) percentage = 100;
+    if (percentage < 0) {
+      percentage = 0;
+    }
+    if (percentage > 100) {
+      percentage = 100;
+    }
     this.silverSending[planetId] = percentage;
     this.gameManager.getGameObjects().forceTick(planetId);
   }
@@ -815,11 +835,17 @@ export class GameUIManager extends EventEmitter {
   }
 
   public setAbandoning(abandoning: boolean): void {
-    if (!this.gameManager.getContractConstants().SPACE_JUNK_ENABLED) return;
+    if (!this.gameManager.getContractConstants().SPACE_JUNK_ENABLED) {
+      return;
+    }
 
     const planet = this.getSelectedPlanet();
-    if (planet?.isHomePlanet) return;
-    if (this.isSendingShip(planet?.locationId)) return;
+    if (planet?.isHomePlanet) {
+      return;
+    }
+    if (this.isSendingShip(planet?.locationId)) {
+      return;
+    }
 
     // An abandon is always a send
     this.isSending = abandoning;
@@ -934,7 +960,9 @@ export class GameUIManager extends EventEmitter {
 
   public setSelectedId(id: LocationId): void {
     const planet = this.getPlanetWithId(id);
-    if (planet && isLocatable(planet)) this.setSelectedPlanet(planet);
+    if (planet && isLocatable(planet)) {
+      this.setSelectedPlanet(planet);
+    }
   }
 
   public setSelectedPlanet(planet: LocatablePlanet | undefined): void {
@@ -951,8 +979,9 @@ export class GameUIManager extends EventEmitter {
       this.selectedCoords = undefined;
     } else {
       const loc = this.getLocationOfPlanet(planet.locationId);
-      if (!loc) this.selectedCoords = undefined;
-      else {
+      if (!loc) {
+        this.selectedCoords = undefined;
+      } else {
         // loc is not undefined
         this.selectedCoords = loc.coords;
 
@@ -972,7 +1001,9 @@ export class GameUIManager extends EventEmitter {
   }
 
   public getMouseDownPlanet(): LocatablePlanet | undefined {
-    if (this.isSending && this.sendingPlanet) return this.sendingPlanet;
+    if (this.isSending && this.sendingPlanet) {
+      return this.sendingPlanet;
+    }
     return this.mouseDownOverPlanet;
   }
 
@@ -1051,7 +1082,9 @@ export class GameUIManager extends EventEmitter {
 
     for (const loc of chunk.planetLocations) {
       const planet = this.getPlanetWithId(loc.hash);
-      if (!planet || !account) break;
+      if (!planet || !account) {
+        break;
+      }
 
       if (planet.owner === EMPTY_ADDRESS && planet.energy > 0) {
         if (
@@ -1180,7 +1213,9 @@ export class GameUIManager extends EventEmitter {
   }
 
   public getMouseDownCoords(): WorldCoords | undefined {
-    if (this.isSending && this.sendingPlanet) return this.sendingCoords;
+    if (this.isSending && this.sendingPlanet) {
+      return this.sendingCoords;
+    }
     return this.mouseDownOverCoords;
   }
 
@@ -1229,10 +1264,16 @@ export class GameUIManager extends EventEmitter {
       config,
       Setting.PlanetDefaultEnergyLevelToSend,
     );
-    if (!planetId) return defaultSending;
+    if (!planetId) {
+      return defaultSending;
+    }
 
-    if (this.isAbandoning()) return 100;
-    if (this.isSendingShip(planetId)) return 0;
+    if (this.isAbandoning()) {
+      return 100;
+    }
+    if (this.isSendingShip(planetId)) {
+      return 0;
+    }
 
     const forces = this.forcesSending[planetId];
     return forces ?? defaultSending;
@@ -1243,10 +1284,16 @@ export class GameUIManager extends EventEmitter {
    */
   public getSilverSending(planetId?: LocationId): number {
     const defaultSending = 0;
-    if (!planetId) return defaultSending;
+    if (!planetId) {
+      return defaultSending;
+    }
 
-    if (this.isAbandoning()) return 100;
-    if (this.isSendingShip(planetId)) return 0;
+    if (this.isAbandoning()) {
+      return 100;
+    }
+    if (this.isSendingShip(planetId)) {
+      return 0;
+    }
 
     return this.silverSending[planetId] ?? defaultSending;
   }
@@ -1256,7 +1303,9 @@ export class GameUIManager extends EventEmitter {
   }
 
   public getArtifactSending(planetId?: LocationId): Artifact | undefined {
-    if (!planetId) return undefined;
+    if (!planetId) {
+      return undefined;
+    }
     return this.artifactSending[planetId];
   }
 
@@ -1281,7 +1330,9 @@ export class GameUIManager extends EventEmitter {
   }
 
   public isSendingShip(planetId?: LocationId): boolean {
-    if (!planetId) return false;
+    if (!planetId) {
+      return false;
+    }
     return isSpaceShip(this.artifactSending[planetId]?.artifactType);
   }
 
@@ -1333,7 +1384,9 @@ export class GameUIManager extends EventEmitter {
   }
 
   public getArtifactPlanet(artifact: Artifact): Planet | undefined {
-    if (!artifact.onPlanetId) return undefined;
+    if (!artifact.onPlanetId) {
+      return undefined;
+    }
     return this.getPlanetWithId(artifact.onPlanetId);
   }
 
@@ -1553,7 +1606,9 @@ export class GameUIManager extends EventEmitter {
 
   public getHomePlanet(): Planet | undefined {
     const homeHash = this.getHomeHash();
-    if (!homeHash) return undefined;
+    if (!homeHash) {
+      return undefined;
+    }
     return this.getPlanetWithId(homeHash);
   }
 
@@ -1638,7 +1693,9 @@ export class GameUIManager extends EventEmitter {
   ): number | undefined {
     // const silverAmount = 10 ** this.player.dropBombAmount;
     const player = this.getPlayer(account);
-    if (!player) return undefined;
+    if (!player) {
+      return undefined;
+    }
     const silverAmount =
       this.contractConstants.BURN_PLANET_REQUIRE_SILVER_AMOUNTS[planetLevel] *
       10 ** player.dropBombAmount;
@@ -1793,7 +1850,9 @@ export class GameUIManager extends EventEmitter {
    */
   public getGlManager(): GameGLManager | null {
     const renderer = this.getRenderer();
-    if (renderer) return renderer.glManager;
+    if (renderer) {
+      return renderer.glManager;
+    }
     return null;
   }
 
@@ -1802,7 +1861,9 @@ export class GameUIManager extends EventEmitter {
    */
   public get2dRenderer(): CanvasRenderingContext2D | null {
     const renderer = this.getRenderer();
-    if (renderer) return renderer.get2DRenderer();
+    if (renderer) {
+      return renderer.get2DRenderer();
+    }
     return null;
   }
 
@@ -1814,7 +1875,9 @@ export class GameUIManager extends EventEmitter {
    */
   public setCustomRenderer(customRenderer: BaseRenderer) {
     const renderer = this.getRenderer();
-    if (renderer) renderer.addCustomRenderer(customRenderer);
+    if (renderer) {
+      renderer.addCustomRenderer(customRenderer);
+    }
   }
 
   /**
@@ -1824,6 +1887,8 @@ export class GameUIManager extends EventEmitter {
    */
   public disableCustomRenderer(customRenderer: BaseRenderer) {
     const renderer = this.getRenderer();
-    if (renderer) renderer.removeCustomRenderer(customRenderer);
+    if (renderer) {
+      renderer.removeCustomRenderer(customRenderer);
+    }
   }
 }

--- a/packages/client/src/Backend/GameLogic/TutorialManager.ts
+++ b/packages/client/src/Backend/GameLogic/TutorialManager.ts
@@ -60,7 +60,9 @@ class TutorialManager extends EventEmitter {
 
   private advance() {
     let newState = Math.min(this.tutorialState + 1, TutorialState.Completed);
-    if (this.shouldSkipState(newState)) newState++;
+    if (this.shouldSkipState(newState)) {
+      newState++;
+    }
 
     this.setTutorialState(newState);
   }
@@ -90,7 +92,9 @@ class TutorialManager extends EventEmitter {
   }
 
   acceptInput(state: TutorialState) {
-    if (state === this.tutorialState) this.advance();
+    if (state === this.tutorialState) {
+      this.advance();
+    }
   }
 }
 

--- a/packages/client/src/Backend/Network/UtilityServerAPI.ts
+++ b/packages/client/src/Backend/Network/UtilityServerAPI.ts
@@ -137,8 +137,9 @@ export async function callRegisterAndWaitForConfirmation(
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const statusResponse = await whitelistStatus(address);
-    if (!statusResponse)
+    if (!statusResponse) {
       return { errorMessage: "Cannot connect to server.", canRetry: false };
+    }
 
     terminal.current?.newline();
     if (statusResponse.failedAt) {

--- a/packages/client/src/Backend/Storage/PersistentChunkStore.ts
+++ b/packages/client/src/Backend/Storage/PersistentChunkStore.ts
@@ -516,7 +516,9 @@ class PersistentChunkStore implements ChunkStore {
    */
   public async onEthTxSubmit(tx: Transaction): Promise<void> {
     // in case the tx was mined and saved already
-    if (!tx.hash || this.confirmedTxHashes.has(tx.hash)) return;
+    if (!tx.hash || this.confirmedTxHashes.has(tx.hash)) {
+      return;
+    }
     const ser: PersistedTransaction = { hash: tx.hash, intent: tx.intent };
     await this.db.put(
       ObjectStore.UNCONFIRMED_ETH_TXS,
@@ -559,14 +561,17 @@ class PersistentChunkStore implements ChunkStore {
   public async saveModalPositions(
     modalPositions: Map<ModalId, ModalPosition>,
   ): Promise<void> {
-    if (!this.db.objectStoreNames.contains(ObjectStore.MODAL_POS)) return;
+    if (!this.db.objectStoreNames.contains(ObjectStore.MODAL_POS)) {
+      return;
+    }
     const serialized = JSON.stringify(Array.from(modalPositions.entries()));
     await this.setKey(MODAL_POSITIONS_KEY, serialized, ObjectStore.MODAL_POS);
   }
 
   public async loadModalPositions(): Promise<Map<ModalId, ModalPosition>> {
-    if (!this.db.objectStoreNames.contains(ObjectStore.MODAL_POS))
+    if (!this.db.objectStoreNames.contains(ObjectStore.MODAL_POS)) {
       return new Map();
+    }
     const winPos = await this.getKey(
       MODAL_POSITIONS_KEY,
       ObjectStore.MODAL_POS,

--- a/packages/client/src/Backend/Storage/ReaderDataStore.ts
+++ b/packages/client/src/Backend/Storage/ReaderDataStore.ts
@@ -123,7 +123,9 @@ class ReaderDataStore {
             break;
           }
         }
-        if (planetLocation) break;
+        if (planetLocation) {
+          break;
+        }
       }
     }
 
@@ -149,7 +151,9 @@ class ReaderDataStore {
     const nowInSeconds = Date.now() / 1000;
 
     for (const arrival of arrivals) {
-      if (nowInSeconds < arrival.arrivalTime) break;
+      if (nowInSeconds < arrival.arrivalTime) {
+        break;
+      }
       arrive(planet, [], arrival, undefined, contractConstants);
     }
 
@@ -179,8 +183,9 @@ class ReaderDataStore {
     if (
       distFromOrigin > MAX_LEVEL_DIST[1] &&
       distFromOrigin < MAX_LEVEL_DIST[0]
-    )
+    ) {
       return SpaceType.NEBULA;
+    }
 
     if (perlin < this.contractConstants.PERLIN_THRESHOLD_1) {
       return SpaceType.NEBULA;
@@ -200,12 +205,18 @@ class ReaderDataStore {
 
     const spaceType = this.spaceTypeFromPerlin(perlin, distFromOrigin);
 
-    if (spaceType === SpaceType.DEAD_SPACE) return Biome.CORRUPTED;
+    if (spaceType === SpaceType.DEAD_SPACE) {
+      return Biome.CORRUPTED;
+    }
 
     let biome = 3 * spaceType;
-    if (biomebase < this.contractConstants.BIOME_THRESHOLD_1) biome += 1;
-    else if (biomebase < this.contractConstants.BIOME_THRESHOLD_2) biome += 2;
-    else biome += 3;
+    if (biomebase < this.contractConstants.BIOME_THRESHOLD_1) {
+      biome += 1;
+    } else if (biomebase < this.contractConstants.BIOME_THRESHOLD_2) {
+      biome += 2;
+    } else {
+      biome += 3;
+    }
 
     return biome as Biome;
   }

--- a/packages/client/src/Frontend/Game/ControllableCanvas.tsx
+++ b/packages/client/src/Frontend/Game/ControllableCanvas.tsx
@@ -84,7 +84,9 @@ export default function ControllableCanvas() {
 
   // TODO fix this
   useLayoutEffect(() => {
-    if (canvasRef.current) doResize();
+    if (canvasRef.current) {
+      doResize();
+    }
   }, [
     // dep array gives eslint issues, but it's fine i tested it i swear - Alan
     canvasRef,
@@ -96,7 +98,9 @@ export default function ControllableCanvas() {
   ]);
 
   useEffect(() => {
-    if (!gameUIManager) return;
+    if (!gameUIManager) {
+      return;
+    }
     // if (!fCanvas && canvasRef.current) {
     //   // setFCanvas(new fabric.Canvas(canvasRef.current));
     // }
@@ -116,8 +120,9 @@ export default function ControllableCanvas() {
 
     // const canvas = fCanvas?.getSelectionElement();
     const canvas = evtRef.current;
-    if (!canvas || !canvasRef.current || !glRef.current || !bufferRef.current)
+    if (!canvas || !canvasRef.current || !glRef.current || !bufferRef.current) {
       return;
+    }
 
     // This zooms your home world in really close to show the awesome details
     // TODO: Store this as it changes and re-initialize to that if stored
@@ -168,7 +173,9 @@ export default function ControllableCanvas() {
 
   // attach event listeners
   useEffect(() => {
-    if (!evtRef.current) return;
+    if (!evtRef.current) {
+      return;
+    }
     const canvas = evtRef.current;
 
     const uiEmitter: UIEmitter = UIEmitter.getInstance();

--- a/packages/client/src/Frontend/Game/ModalManager.ts
+++ b/packages/client/src/Frontend/Game/ModalManager.ts
@@ -51,7 +51,9 @@ class ModalManager extends EventEmitter {
   }
 
   public acceptInputForTarget(input: WorldCoords): void {
-    if (this.cursorState !== CursorState.TargetingExplorer) return;
+    if (this.cursorState !== CursorState.TargetingExplorer) {
+      return;
+    }
     this.emit(ModalManagerEvent.MiningCoordsUpdate, input);
     this.setCursorState(CursorState.Normal);
   }
@@ -63,10 +65,14 @@ class ModalManager extends EventEmitter {
   public getModalPositions(
     modalIds: ModalId[] = [],
   ): Map<ModalId, ModalPosition> {
-    if (modalIds.length === 0) return this.modalPositions;
+    if (modalIds.length === 0) {
+      return this.modalPositions;
+    }
     return modalIds.reduce<Map<ModalId, ModalPosition>>((acc, cur) => {
       const winPos = this.modalPositions.get(cur);
-      if (!winPos) return acc;
+      if (!winPos) {
+        return acc;
+      }
       return acc.set(cur, winPos);
     }, new Map());
   }

--- a/packages/client/src/Frontend/Game/NotificationManager.tsx
+++ b/packages/client/src/Frontend/Game/NotificationManager.tsx
@@ -101,7 +101,9 @@ const BiomeNotificationMap = {
   [Biome.CORRUPTED]: NotificationType.FoundBiomeCorrupted,
 };
 function getNotificationTypeFromPlanetBiome(biome: Biome): NotificationType {
-  if (!biome) throw new Error("Biome is a required to get a NotificationType");
+  if (!biome) {
+    throw new Error("Biome is a required to get a NotificationType");
+  }
   return BiomeNotificationMap[biome];
 }
 

--- a/packages/client/src/Frontend/Game/Popups.ts
+++ b/packages/client/src/Frontend/Game/Popups.ts
@@ -46,7 +46,9 @@ export async function openConfirmationWindowForTransaction({
     localStorage.setItem(`${from}-gasFeeGwei`, gasFeeGwei.toString());
     localStorage.setItem(`${from}-gasFeeLimit`, gasFeeLimit.toString());
     const account = connection.getAddress();
-    if (!account) throw new Error("no account");
+    if (!account) {
+      throw new Error("no account");
+    }
     const balanceEth = weiToEth(await connection.loadBalance(account));
     const method = intent.methodName;
     const popup = window.open(

--- a/packages/client/src/Frontend/Game/Viewport.ts
+++ b/packages/client/src/Frontend/Game/Viewport.ts
@@ -252,7 +252,9 @@ class Viewport {
   getStorage(): ViewportData | undefined {
     const key = this.getStorageKey();
     const stored = localStorage.getItem(key);
-    if (stored) return (JSON.parse(stored) as ViewportData) || undefined;
+    if (stored) {
+      return (JSON.parse(stored) as ViewportData) || undefined;
+    }
     return undefined;
   }
 
@@ -283,7 +285,9 @@ class Viewport {
 
   // centers on a planet and makes it fill the viewport
   zoomPlanet(planet?: Planet, radii?: number): void {
-    if (!planet || !isLocatable(planet)) return;
+    if (!planet || !isLocatable(planet)) {
+      return;
+    }
     this.centerPlanet(planet);
     // in world coords
     const rad = this.gameUIManager.getRadiusOfPlanetLevel(planet.planetLevel);
@@ -294,8 +298,9 @@ class Viewport {
   }
 
   centerCoords(coords: WorldCoords): void {
-    if (typeof coords.x !== "number" || typeof coords.y !== "number")
+    if (typeof coords.x !== "number" || typeof coords.y !== "number") {
       throw new Error("please pass in an object that looks like {x: 0, y: 0}");
+    }
     this.centerWorldCoords = { ...coords };
   }
 
@@ -317,7 +322,9 @@ class Viewport {
 
   // Event handlers
   onMouseDown(canvasCoords: CanvasCoords) {
-    if (this.isSending) return;
+    if (this.isSending) {
+      return;
+    }
 
     this.mousedownCoords = canvasCoords;
 

--- a/packages/client/src/Frontend/Pages/GameLandingPage.tsx
+++ b/packages/client/src/Frontend/Pages/GameLandingPage.tsx
@@ -546,7 +546,9 @@ export function GameLandingPage() {
     async (terminal: React.MutableRefObject<TerminalHandle | undefined>) => {
       try {
         const playerAddress = ethConnection?.getAddress();
-        if (!playerAddress || !ethConnection) throw new Error("not logged in");
+        if (!playerAddress || !ethConnection) {
+          throw new Error("not logged in");
+        }
 
         terminal.current?.println("Checking account balance... ");
 
@@ -738,7 +740,9 @@ export function GameLandingPage() {
   const advanceStateFromAskWhitelistKey = useCallback(
     async (terminal: React.MutableRefObject<TerminalHandle | undefined>) => {
       const address = ethConnection?.getAddress();
-      if (!address) throw new Error("not logged in");
+      if (!address) {
+        throw new Error("not logged in");
+      }
 
       terminal.current?.println(
         "Please enter your invite key (XXXXXX-XXXXXX-XXXXXX-XXXXXX):",
@@ -799,7 +803,9 @@ export function GameLandingPage() {
           setStep(TerminalPromptStep.ASKING_PLAYER_EMAIL);
         }
       } else {
-        if (!ethConnection) throw new Error("no eth connection");
+        if (!ethConnection) {
+          throw new Error("no eth connection");
+        }
         const contractsAPI = await makeContractsAPI({
           connection: ethConnection,
           contractAddress,
@@ -933,7 +939,9 @@ export function GameLandingPage() {
   const advanceStateFromAskPlayerEmail = useCallback(
     async (terminal: React.MutableRefObject<TerminalHandle | undefined>) => {
       const address = ethConnection?.getAddress();
-      if (!address) throw new Error("not logged in");
+      if (!address) {
+        throw new Error("not logged in");
+      }
 
       terminal.current?.print(
         "Enter your email address. ",
@@ -970,7 +978,9 @@ export function GameLandingPage() {
       let newGameManager: GameManager;
 
       try {
-        if (!ethConnection) throw new Error("no eth connection");
+        if (!ethConnection) {
+          throw new Error("no eth connection");
+        }
 
         newGameManager = await GameManager.create({
           connection: ethConnection,
@@ -1521,7 +1531,9 @@ export function GameLandingPage() {
   const advanceStateFromSpectating = useCallback(
     async (terminal: React.MutableRefObject<TerminalHandle | undefined>) => {
       try {
-        if (!ethConnection) throw new Error("not logged in");
+        if (!ethConnection) {
+          throw new Error("not logged in");
+        }
 
         setSpectate(true);
         setMiniMapOn(false);

--- a/packages/client/src/Frontend/Pages/GifMaker.tsx
+++ b/packages/client/src/Frontend/Pages/GifMaker.tsx
@@ -31,7 +31,9 @@ export function GifMaker() {
 
   const [renderer, setRenderer] = useState<GifRenderer | null>(null);
   useEffect(() => {
-    if (!canvasRef.current) return;
+    if (!canvasRef.current) {
+      return;
+    }
 
     setRenderer(new GifRenderer(canvasRef.current, GIF_DIM, IS_THUMB));
   }, [canvasRef]);

--- a/packages/client/src/Frontend/Renderers/Artifacts/ArtifactRenderer.ts
+++ b/packages/client/src/Frontend/Renderers/Artifacts/ArtifactRenderer.ts
@@ -130,8 +130,11 @@ export class ArtifactRenderer extends WebGLManager {
   }
 
   private draw() {
-    if (this.isDex) this.drawDex();
-    else this.drawList();
+    if (this.isDex) {
+      this.drawDex();
+    } else {
+      this.drawList();
+    }
 
     this.spriteRenderer.flush();
   }

--- a/packages/client/src/Frontend/Renderers/GifRenderer.ts
+++ b/packages/client/src/Frontend/Renderers/GifRenderer.ts
@@ -163,8 +163,11 @@ export class GifRenderer extends WebGLManager {
         rarity++
       ) {
         for (let biome = MIN_BIOME; biome <= MAX_BIOME; biome++) {
-          if (videoMode) await this.addVideo(dir, type, biome, rarity, false);
-          else this.addSprite(dir, type, biome, rarity, false);
+          if (videoMode) {
+            await this.addVideo(dir, type, biome, rarity, false);
+          } else {
+            this.addSprite(dir, type, biome, rarity, false);
+          }
         }
       }
     }
@@ -178,9 +181,11 @@ export class GifRenderer extends WebGLManager {
         rarity <= MAX_ARTIFACT_RARITY;
         rarity++
       ) {
-        if (videoMode)
+        if (videoMode) {
           await this.addVideo(dir, type, Biome.OCEAN, rarity, true);
-        else this.addSprite(dir, type, Biome.OCEAN, rarity, true);
+        } else {
+          this.addSprite(dir, type, Biome.OCEAN, rarity, true);
+        }
       }
     }
   }

--- a/packages/client/src/Frontend/Renderers/LandingPageCanvas.tsx
+++ b/packages/client/src/Frontend/Renderers/LandingPageCanvas.tsx
@@ -91,7 +91,9 @@ class LandingPageCanvasRenderer {
     for (let i = 0; i < numEdges; i++) {
       const p1 = Math.floor(Math.random() * numPoints);
       let p2 = p1;
-      while (p2 === p1) p2 = Math.floor(Math.random() * numPoints);
+      while (p2 === p1) {
+        p2 = Math.floor(Math.random() * numPoints);
+      }
       newEdges.push([p1, p2]);
     }
 
@@ -244,7 +246,9 @@ class LandingPageCanvasRenderer {
   }
 
   private mouseMove(e: MouseEvent) {
-    if (!this.allowMouse()) return;
+    if (!this.allowMouse()) {
+      return;
+    }
     this._mouseMove(e);
   }
 
@@ -260,7 +264,9 @@ class LandingPageCanvasRenderer {
       if (base.x ** 2 + base.y ** 2 > max ** 2) {
         const mult = max / Math.sqrt(base.x ** 2 + base.y ** 2);
         return { x: base.x * mult, y: base.y * mult };
-      } else return base;
+      } else {
+        return base;
+      }
     };
 
     const _tIdentity = (x: Position, _m: number) => x;
@@ -315,9 +321,11 @@ export default function LandingPageCanvas() {
   }, []);
 
   useEffect(() => {
-    if (canvasRef.current)
+    if (canvasRef.current) {
       LandingPageCanvasRenderer.initialize(canvasRef.current);
-    else console.error("could not init draw");
+    } else {
+      console.error("could not init draw");
+    }
 
     window.addEventListener("resize", onResize);
 

--- a/packages/client/src/Frontend/Utils/EmitterUtils.ts
+++ b/packages/client/src/Frontend/Utils/EmitterUtils.ts
@@ -32,7 +32,9 @@ export function getObjectWithIdFromMap<Obj, Id>(
   });
 
   objUpdated$.subscribe((id: Id) => {
-    if (lastId && lastId === id) publishIdEvent(id);
+    if (lastId && lastId === id) {
+      publishIdEvent(id);
+    }
   });
 
   return selectedObj$;
@@ -57,7 +59,9 @@ export function getDisposableEmitter<Obj, Id>(
   };
 
   objUpdated$.subscribe((id: Id) => {
-    if (objId === id) publishIdEvent(id);
+    if (objId === id) {
+      publishIdEvent(id);
+    }
   });
 
   return selectedObj$;

--- a/packages/client/src/Frontend/Utils/KeyEmitters.ts
+++ b/packages/client/src/Frontend/Utils/KeyEmitters.ts
@@ -12,17 +12,19 @@ export const keyUp$ = monomitter<Wrapper<string>>();
 export const keyDown$ = monomitter<Wrapper<string>>();
 
 const onKeyUp = (e: KeyboardEvent) => {
-  if (!shouldIgnoreShortcutKeypress(e))
+  if (!shouldIgnoreShortcutKeypress(e)) {
     keyUp$.publish(
       new Wrapper(getSpecialKeyFromEvent(e) || e.key.toLowerCase()),
     );
+  }
 };
 
 const onKeyDown = (e: KeyboardEvent) => {
-  if (!shouldIgnoreShortcutKeypress(e))
+  if (!shouldIgnoreShortcutKeypress(e)) {
     keyDown$.publish(
       new Wrapper(getSpecialKeyFromEvent(e) || e.key.toLowerCase()),
     );
+  }
 };
 
 export function listenForKeyboardEvents() {
@@ -41,8 +43,9 @@ export function unlinkKeyboardEvents() {
  */
 function shouldIgnoreShortcutKeypress(e: KeyboardEvent): boolean {
   const targetElement = e.target as HTMLElement;
-  if (targetElement.tagName === "INPUT")
+  if (targetElement.tagName === "INPUT") {
     return targetElement.attributes.getNamedItem("type")?.value !== "range";
+  }
   return targetElement.tagName === "TEXTAREA";
 }
 

--- a/packages/client/src/PlanetTest/PlanetUpgradeFormBranchTest.tsx
+++ b/packages/client/src/PlanetTest/PlanetUpgradeFormBranchTest.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
 import { useMUD } from "@mud/MUDContext";
+import React, { useState } from "react";
 
 interface PlanetUpgradeProps {
   onSubmit: (planetHash: string, branch: number) => void;

--- a/packages/client/src/PlanetTest/PlayerForm.tsx
+++ b/packages/client/src/PlanetTest/PlayerForm.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
-import { useMUD } from "@mud/MUDContext";
 import { entityToAddress } from "@frontend/Pages/GamePage";
+import { useMUD } from "@mud/MUDContext";
+import React, { useState } from "react";
 import { useAccount } from "wagmi";
 const PlayerForm = () => {
   const {

--- a/packages/client/src/PlanetTest/ProofVerificationForm.tsx
+++ b/packages/client/src/PlanetTest/ProofVerificationForm.tsx
@@ -73,7 +73,6 @@ export const ProofVerificationForm: React.FC = () => {
           console.log("SpawnProof", aValues, bValues, cValues, inputValues);
           break;
 
-
         case "MoveProof":
           result = verifyMoveProof(
             {
@@ -97,7 +96,6 @@ export const ProofVerificationForm: React.FC = () => {
               perlinMirrorY: inputValues[9],
               toRadiusSquare: inputValues[10],
             },
-
           );
           console.log("Move proof", aValues, bValues, cValues, inputValues);
           break;

--- a/packages/client/src/PlanetTest/RevealPlanetForm.tsx
+++ b/packages/client/src/PlanetTest/RevealPlanetForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
 import { useMUD } from "@mud/MUDContext";
+import React, { useState } from "react";
 
 export const RevealPlanetForm: React.FC = () => {
   const {

--- a/packages/client/src/Shared/network/ContractCaller.ts
+++ b/packages/client/src/Shared/network/ContractCaller.ts
@@ -33,8 +33,12 @@ export class ContractCaller {
   private diagnosticsUpdater?: DiagnosticUpdater;
 
   public constructor(queue?: Queue, maxRetries?: number) {
-    if (queue) this.queue = queue;
-    if (maxRetries) this.maxRetries = maxRetries;
+    if (queue) {
+      this.queue = queue;
+    }
+    if (maxRetries) {
+      this.maxRetries = maxRetries;
+    }
   }
 
   /**

--- a/packages/client/src/Shared/network/EthConnection.ts
+++ b/packages/client/src/Shared/network/EthConnection.ts
@@ -409,7 +409,9 @@ export class EthConnection {
   public sendTransaction(
     request: providers.TransactionRequest,
   ): Promise<providers.TransactionResponse> {
-    if (!this.signer) throw new Error(`no signer`);
+    if (!this.signer) {
+      throw new Error(`no signer`);
+    }
     return this.signer.sendTransaction(request);
   }
 

--- a/packages/client/src/Shared/network/ThrottledConcurrentQueue.ts
+++ b/packages/client/src/Shared/network/ThrottledConcurrentQueue.ts
@@ -142,7 +142,9 @@ export class ThrottledConcurrentQueue<U = unknown> implements Queue {
       (task: QueuedTask<unknown, U>) => predicate(task.metadata),
     );
 
-    if (foundIndex === -1) throw new Error(`specified task was not found`);
+    if (foundIndex === -1) {
+      throw new Error(`specified task was not found`);
+    }
 
     return this.taskQueue.splice(foundIndex, 1)[0];
   }
@@ -165,7 +167,9 @@ export class ThrottledConcurrentQueue<U = unknown> implements Queue {
       (task: QueuedTask<unknown, U>) => predicate(task.metadata),
     );
 
-    if (foundIndex === -1) throw new Error(`specified task was not found`);
+    if (foundIndex === -1) {
+      throw new Error(`specified task was not found`);
+    }
 
     const foundTask = this.taskQueue.splice(foundIndex, 1)[0];
     this.taskQueue.push(foundTask);

--- a/packages/client/src/Shared/network/TxExecutor.ts
+++ b/packages/client/src/Shared/network/TxExecutor.ts
@@ -321,7 +321,9 @@ export class TxExecutor {
     }
 
     const nonce = this.nonce;
-    if (this.nonce !== undefined) this.nonce++;
+    if (this.nonce !== undefined) {
+      this.nonce++;
+    }
 
     return nonce;
   }


### PR DESCRIPTION
what the title says ☝️ , we should always prefer readability over simplicity and eventual bugs when compiling JS that are difficult to discover in running code…

As it says [here](https://eslint.org/docs/latest/rules/curly) 
> JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity. So the following:

[Rule details](https://eslint.org/docs/latest/rules/curly#rule-details)
> This rule is aimed at preventing bugs and increasing code clarity by ensuring that block statements are wrapped in curly braces. It will warn when it encounters blocks that omit curly braces.