### PR TITLE
chore: enforce no explicit any

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -74,6 +74,6 @@ module.exports = {
     // "no-only-tests/no-only-tests": "error",
     "simple-import-sort/imports": "warn",
     "simple-import-sort/exports": "warn",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "error",
   },
 };

--- a/packages/client/src/Backend/GameLogic/InitialGameStateDownloader.tsx
+++ b/packages/client/src/Backend/GameLogic/InitialGameStateDownloader.tsx
@@ -87,7 +87,7 @@ export class InitialGameStateDownloader {
       await persistentChunkStore.getSavedClaimedCoords();
     const storedBurnedCoords =
       await persistentChunkStore.getSavedBurnedCoords();
-    const storedKardashevCoords: any[] = [];
+    const storedKardashevCoords: KardashevCoords[] = [];
     //TODO: fix this
     // await persistentChunkStore.getSavedKardashevCoords();
 

--- a/packages/client/src/PlanetTest/ProofVerificationForm.tsx
+++ b/packages/client/src/PlanetTest/ProofVerificationForm.tsx
@@ -73,7 +73,6 @@ export const ProofVerificationForm: React.FC = () => {
           console.log("SpawnProof", aValues, bValues, cValues, inputValues);
           break;
 
-
         case "MoveProof":
           result = verifyMoveProof(
             {
@@ -97,7 +96,6 @@ export const ProofVerificationForm: React.FC = () => {
               perlinMirrorY: inputValues[9],
               toRadiusSquare: inputValues[10],
             },
-
           );
           console.log("Move proof", aValues, bValues, cValues, inputValues);
           break;

--- a/packages/client/src/Shared/network/TxExecutor.ts
+++ b/packages/client/src/Shared/network/TxExecutor.ts
@@ -454,12 +454,10 @@ export class TxExecutor {
       logEvent.wait_error = time_errored - time_exec_called;
 
       try {
-        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        if ((error as any).body) {
-          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        if ("body" in error) {
           logEvent.parsed_error = String.fromCharCode.apply(
             null,
-            (error as any).body || [],
+            Array.isArray(error.body) ? error.body : [],
           );
         }
       } catch (e) {


### PR DESCRIPTION
what the title says. ☝️ , as the eslint rule says [here](https://typescript-eslint.io/rules/no-explicit-any/):
>The any type in TypeScript is a dangerous "escape hatch" from the type system. Using any disables many type checking rules and is generally best used only as a last resort or when prototyping code. This rule reports on explicit uses of the any keyword as a type annotation.

Also on why TS no implicit any does not enforce this.
>TypeScript's --noImplicitAny compiler option prevents an implied any, but doesn't prevent any from being explicitly used the way this rule does.

This rules enforces to take choices and read the code, and say something is of type X and not Y which also reduces debug time when things go wrong…