### PR TITLE
chore: ignore .nvmrc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ packages/classic-packages
 
 mprocs.log
 
+# node version manager file
+.nvmrc
+
 # Local Netlify folder
 .netlify


### PR DESCRIPTION
I want to ignore the [node version manager](https://github.com/nvm-sh/nvm) file`.nvmrc` file to make it easier to switch between the current LTS version 22 of node, and the version 20 of node that i'm using for this project.