### PR TITLE
chore: add functionality to replace lodash-es

### DIFF
--- a/packages/client/src/Backend/GameLogic/InitialGameStateDownloader.tsx
+++ b/packages/client/src/Backend/GameLogic/InitialGameStateDownloader.tsx
@@ -12,7 +12,6 @@ import type {
   RevealedCoords,
   VoyageId,
 } from "@df/types";
-import { flatMap } from "lodash-es";
 import React from "react";
 
 import type { ContractConstants } from "../../_types/darkforest/api/ContractsAPITypes";
@@ -139,7 +138,7 @@ export class InitialGameStateDownloader {
 
     const minedChunks = Array.from(await persistentChunkStore.allChunks());
     const minedPlanetIds = new Set(
-      flatMap(minedChunks, (c) => c.planetLocations).map((l) => l.hash),
+      minedChunks.flatMap((c) => c.planetLocations).map((l) => l.hash),
     );
 
     const loadedTouchedPlanetIds = await contractsAPI.getTouchedPlanetIds(

--- a/packages/client/src/Frontend/Game/NotificationManager.tsx
+++ b/packages/client/src/Frontend/Game/NotificationManager.tsx
@@ -9,8 +9,8 @@ import type {
   TxIntent,
 } from "@df/types";
 import { Biome } from "@df/types";
+import { startCase } from "@df/utils/string";
 import EventEmitter from "events";
-import { startCase } from "lodash-es";
 import React from "react";
 
 import { getRandomActionId } from "../../Backend/Utils/Utils";

--- a/packages/client/src/Frontend/Pages/GameLandingPage.tsx
+++ b/packages/client/src/Frontend/Pages/GameLandingPage.tsx
@@ -11,6 +11,7 @@ import { neverResolves, weiToEth } from "@df/network";
 import { address } from "@df/serde";
 import { addressToHex } from "@df/serde";
 import type { UnconfirmedUseKey } from "@df/types";
+import { reversed } from "@df/utils/list";
 import { bigIntFromKey } from "@df/whitelist";
 import { RegisterPlayerComponent } from "@frontend/Components/RegisterPlayerComponent";
 import { WalletModal } from "@frontend/Components/WalletModal";
@@ -26,7 +27,6 @@ import {
 import { useMUD } from "@mud/MUDContext";
 import { LOW_BALANCE_THRESHOLD, RECOMMENDED_BALANCE } from "@wallet/utils";
 import { utils, Wallet } from "ethers";
-import { reverse } from "lodash-es";
 import React, {
   useCallback,
   useEffect,
@@ -350,7 +350,7 @@ export function GameLandingPage() {
 
         // Search accounts backwards in case a player has used a private key more than once.
         // In that case, we want to take the most recently created account.
-        const account = reverse(getAccounts()).find(
+        const account = reversed(getAccounts()).find(
           (a) => a.address === selectedAddress,
         );
         if (!account) {

--- a/packages/client/src/Frontend/Panes/ArtifactDetailsPane.tsx
+++ b/packages/client/src/Frontend/Panes/ArtifactDetailsPane.tsx
@@ -15,7 +15,7 @@ import type {
   Upgrade,
 } from "@df/types";
 import { ArtifactRarityNames, ArtifactType, TooltipName } from "@df/types";
-import _ from "lodash-es";
+import { range } from "@df/utils/number";
 import styled from "styled-components";
 
 import type { ContractConstants } from "../../_types/darkforest/api/ContractsAPITypes";
@@ -304,7 +304,7 @@ export function ArtifactDetailsBody({
       {hasStatBoost(artifact.artifactType) && (
         <ArtifactDetailsHeader>
           <StatsContainer>
-            {_.range(0, 5).map((val) => (
+            {range(0, 5).map((val) => (
               <UpgradeStatInfo
                 upgrades={[artifact.upgrade, artifact.timeDelayedUpgrade]}
                 stat={val}

--- a/packages/client/src/Frontend/Panes/Lobbies/CaptureZonesPane.tsx
+++ b/packages/client/src/Frontend/Panes/Lobbies/CaptureZonesPane.tsx
@@ -1,4 +1,3 @@
-import _ from "lodash-es";
 import React from "react";
 
 import type {
@@ -41,7 +40,7 @@ const rowStyle = { gap: "8px" } as CSSStyleDeclaration & React.CSSProperties;
 export function CaptureZonesPane({ config, onUpdate }: LobbiesPaneProps) {
   let captureZoneOptions = null;
   if (config.CAPTURE_ZONES_ENABLED.currentValue === true) {
-    const scores = _.chunk(
+    const scores = chunk(
       config.CAPTURE_ZONE_PLANET_LEVEL_SCORE.displayValue,
       rowChunkSize,
     ).map((items, rowIdx) => {

--- a/packages/client/src/Frontend/Panes/Lobbies/ConfigurationPane.tsx
+++ b/packages/client/src/Frontend/Panes/Lobbies/ConfigurationPane.tsx
@@ -1,5 +1,5 @@
 import type { EthAddress } from "@df/types";
-import _ from "lodash-es";
+import { chunk } from "@df/utils/list";
 import React, { useEffect, useReducer, useState } from "react";
 import { Route, Switch, useRouteMatch } from "react-router-dom";
 
@@ -135,7 +135,7 @@ function ConfigurationNavigation({
   status: Status;
   onCreate: () => Promise<void>;
 }) {
-  const buttons = _.chunk(panes, 2).map(([fst, snd], idx) => {
+  const buttons = chunk(panes, 2).map(([fst, snd], idx) => {
     return (
       // Index key is fine here because the array is stable
       <ButtonRow key={idx}>

--- a/packages/client/src/Frontend/Panes/Lobbies/PlanetPane.tsx
+++ b/packages/client/src/Frontend/Panes/Lobbies/PlanetPane.tsx
@@ -1,4 +1,4 @@
-import _ from "lodash-es";
+import { chunk } from "@df/utils/list";
 import React from "react";
 
 import type { DarkForestNumberInput } from "../../Components/Input";
@@ -53,7 +53,7 @@ function ThresholdByPlanetLevel({
 export function PlanetPane({ config, onUpdate }: LobbiesPaneProps) {
   let planetLevelThresholds = null;
   if (config.PLANET_LEVEL_THRESHOLDS.displayValue) {
-    planetLevelThresholds = _.chunk(
+    planetLevelThresholds = chunk(
       config.PLANET_LEVEL_THRESHOLDS.displayValue,
       rowChunkSize,
     ).map((items, rowIdx) => {

--- a/packages/client/src/Frontend/Panes/Lobbies/RewardsPane.tsx
+++ b/packages/client/src/Frontend/Panes/Lobbies/RewardsPane.tsx
@@ -1,5 +1,5 @@
 import { TOKEN_NAME } from "@df/constants";
-import _ from "lodash-es";
+import { chunk } from "@df/utils/list";
 import React from "react";
 
 import type { DarkForestNumberInput } from "../../Components/Input";
@@ -39,7 +39,7 @@ function RewardByPlayerRank({
 export function RewardsPane({ config, onUpdate }: LobbiesPaneProps) {
   let rewardInputs = null;
   if (config.ROUND_END_REWARDS_BY_RANK.displayValue) {
-    rewardInputs = _.chunk(
+    rewardInputs = chunk(
       config.ROUND_END_REWARDS_BY_RANK.displayValue,
       rowChunkSize,
     ).map((items, rowIdx) => {

--- a/packages/client/src/Frontend/Panes/Lobbies/SpaceJunkPane.tsx
+++ b/packages/client/src/Frontend/Panes/Lobbies/SpaceJunkPane.tsx
@@ -1,4 +1,4 @@
-import _ from "lodash-es";
+import { chunk } from "@df/utils/list";
 import React from "react";
 
 import type {
@@ -38,24 +38,23 @@ const junkRowStyle = { gap: "8px" } as CSSStyleDeclaration &
 export function SpaceJunkPane({ config, onUpdate }: LobbiesPaneProps) {
   let spaceJunkOptions = null;
   if (config.SPACE_JUNK_ENABLED.currentValue === true) {
-    const junk = _.chunk(
-      config.PLANET_LEVEL_JUNK.displayValue,
-      rowChunkSize,
-    ).map((items, rowIdx) => {
-      return (
-        <Row key={`junk-row-${rowIdx}`} style={junkRowStyle}>
-          {items.map((displayValue, idx) => (
-            <JunkPerLevel
-              key={`junk-lvl-${idx}`}
-              config={config}
-              value={displayValue}
-              index={rowIdx * rowChunkSize + idx}
-              onUpdate={onUpdate}
-            />
-          ))}
-        </Row>
-      );
-    });
+    const junk = chunk(config.PLANET_LEVEL_JUNK.displayValue, rowChunkSize).map(
+      (items, rowIdx) => {
+        return (
+          <Row key={`junk-row-${rowIdx}`} style={junkRowStyle}>
+            {items.map((displayValue, idx) => (
+              <JunkPerLevel
+                key={`junk-lvl-${idx}`}
+                config={config}
+                value={displayValue}
+                index={rowIdx * rowChunkSize + idx}
+                onUpdate={onUpdate}
+              />
+            ))}
+          </Row>
+        );
+      },
+    );
     spaceJunkOptions = (
       <>
         <Row>

--- a/packages/client/src/Frontend/Panes/TransactionLogPane.tsx
+++ b/packages/client/src/Frontend/Panes/TransactionLogPane.tsx
@@ -27,7 +27,9 @@ import {
   type Transaction,
 } from "@df/types";
 import { IconType } from "@df/ui";
-import { isEmpty, reverse, startCase, values } from "lodash-es";
+import { isEmpty } from "@df/utils/comparison";
+import { reversed } from "@df/utils/list";
+import { startCase } from "@df/utils/string";
 import { useCallback } from "react";
 import Loader from "react-loader-spinner";
 import TimeAgo from "react-timeago";
@@ -282,7 +284,7 @@ function QueuedTransactionsTable({
   transactions: Wrapper<TransactionRecord>;
 }) {
   const uiManager = useUIManager();
-  const visibleTransactions = reverse(values(transactions.value));
+  const visibleTransactions = reversed(Object.values(transactions.value));
 
   const headers = ["Type", "Hash", "State", "Planet", "Updated", "Actions"];
   const alignments: Array<"r" | "c" | "l"> = ["c", "c", "c", "c", "c", "c"];
@@ -309,7 +311,7 @@ function QueuedTransactionsTable({
   );
 
   const queuedTransctions = useCallback(() => {
-    return values(transactions.value).filter((tx) =>
+    return Object.values(transactions.value).filter((tx) =>
       ["Init", "Prioritized"].includes(tx.state),
     );
   }, [transactions]);

--- a/packages/client/src/Frontend/Views/DarkForestTips.tsx
+++ b/packages/client/src/Frontend/Views/DarkForestTips.tsx
@@ -1,4 +1,4 @@
-import { shuffle } from "lodash-es";
+import { shuffle } from "@df/utils/list";
 import { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 

--- a/packages/client/src/Frontend/Views/Notifications.tsx
+++ b/packages/client/src/Frontend/Views/Notifications.tsx
@@ -1,5 +1,4 @@
 import { Setting } from "@df/types";
-import _ from "lodash-es";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
@@ -67,7 +66,7 @@ export function NotificationsPane() {
       }
 
       setNotifs((arr) => {
-        const newArr = _.clone(arr);
+        const newArr = structuredClone(arr);
         for (let i = 0; i < arr.length; i++) {
           if (arr[i].id === notif.id) {
             newArr[i] = notif;
@@ -98,7 +97,7 @@ export function NotificationsPane() {
   // creates a callback for a notif which removes itself
   const getRemove = (notif: NotificationInfo): (() => void) => {
     return (): void => {
-      const copy = _.clone(notifs);
+      const copy = structuredClone(notifs);
       for (let i = 0; i < copy.length; i++) {
         if (copy[i].id === notif.id) {
           copy.splice(i, 1);

--- a/packages/client/src/Shared/utils/comparison/index.ts
+++ b/packages/client/src/Shared/utils/comparison/index.ts
@@ -1,0 +1,1 @@
+export { isEmpty } from "./is-empty";

--- a/packages/client/src/Shared/utils/comparison/is-empty.ts
+++ b/packages/client/src/Shared/utils/comparison/is-empty.ts
@@ -1,0 +1,11 @@
+export function isEmpty(value: object): boolean {
+  if (Object.hasOwn(value, "length")) {
+    return (value as { length: number }).length === 0;
+  }
+
+  if (Object.hasOwn(value, "size")) {
+    return (value as { size: number }).size === 0;
+  }
+
+  return Object.keys(value).length > 0;
+}

--- a/packages/client/src/Shared/utils/list/chunk.ts
+++ b/packages/client/src/Shared/utils/list/chunk.ts
@@ -1,0 +1,13 @@
+export function chunk<T>(items: readonly T[] | T[], size: number = 1): T[][] {
+  // Handle edge cases
+  if (!items.length || size < 1) {
+    return [];
+  }
+
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+
+  return chunks;
+}

--- a/packages/client/src/Shared/utils/list/index.ts
+++ b/packages/client/src/Shared/utils/list/index.ts
@@ -1,0 +1,3 @@
+export { chunk } from "./chunk";
+export { reversed } from "./reversed";
+export { shuffle } from "./shuffle";

--- a/packages/client/src/Shared/utils/list/reversed.ts
+++ b/packages/client/src/Shared/utils/list/reversed.ts
@@ -1,0 +1,14 @@
+const supportstoReversed = typeof [].toReversed === "function";
+
+export function reversed<T>(items: T[]): T[] {
+  if (supportstoReversed) {
+    return items.toReversed();
+  }
+
+  const result: T[] = [];
+  for (let i = items.length; i--; ) {
+    result.push(items[i]);
+  }
+
+  return result;
+}

--- a/packages/client/src/Shared/utils/list/shuffle.ts
+++ b/packages/client/src/Shared/utils/list/shuffle.ts
@@ -1,0 +1,14 @@
+// Fisher-Yates (also known as Knuth) shuffle implementation
+
+export function shuffle<T>(items: T[]): T[] {
+  // Clone the list to avoid mutating the original
+  const result = [...items];
+
+  // Start from the last element and swap with random earlier element
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+
+  return result;
+}

--- a/packages/client/src/Shared/utils/number/index.ts
+++ b/packages/client/src/Shared/utils/number/index.ts
@@ -1,0 +1,1 @@
+export { range } from "./range";

--- a/packages/client/src/Shared/utils/number/range.ts
+++ b/packages/client/src/Shared/utils/number/range.ts
@@ -1,0 +1,8 @@
+export function range(start: number, stop: number, step: number = 1) {
+  const numbers = [];
+  for (let value = start; value < stop; value += step) {
+    numbers.push(value);
+  }
+
+  return numbers;
+}

--- a/packages/client/src/Shared/utils/string/index.ts
+++ b/packages/client/src/Shared/utils/string/index.ts
@@ -1,0 +1,1 @@
+export { startCase } from "./start-case";

--- a/packages/client/src/Shared/utils/string/start-case.ts
+++ b/packages/client/src/Shared/utils/string/start-case.ts
@@ -1,0 +1,7 @@
+const pattern = /[a-zA-z]+/g;
+
+export function startCase(value: string): string {
+  return Array.from(value.matchAll(pattern))
+    .map(([[fst, ...rest]]) => `${fst.toUpperCase()}${rest}`)
+    .join(" ");
+}


### PR DESCRIPTION
Follow up on #139, seems that there was more functionality used from `lodash` than what i saw when i forked from main.
This should fix the last bits and pieces.

## Testing:
I have tested that most of the utility replacements functions work as expected will add tests for those functions in a separate PR, and start introducing test suites for our JS codebase gradually (we can't keep going on without tests like we have done for some time now).