### PR TITLE
Memory Monitor Plugin

### DIFF
--- a/packages/client/embedded_plugins/MemoryMonitor.js
+++ b/packages/client/embedded_plugins/MemoryMonitor.js
@@ -8,11 +8,6 @@ class MemoryMonitor {
     const element = this.#element;
     element.insertAdjacentHTML("afterbegin", this.renderHTML());
 
-    // style parent container and insert our element
-    // container.parentElement.style.minHeight = "unset";
-    // container.style.width = "300px";
-    // container.style.minHeight = "unset";
-
     container.appendChild(element);
     this.runUpdate();
   }

--- a/packages/client/embedded_plugins/MemoryMonitor.js
+++ b/packages/client/embedded_plugins/MemoryMonitor.js
@@ -1,0 +1,73 @@
+class MemoryMonitor {
+  #element = document.createElement("memory-monitor", {
+    is: "div",
+  });
+  #destroyed = false;
+
+  render(container) {
+    const element = this.#element;
+    element.insertAdjacentHTML("afterbegin", this.renderHTML());
+
+    // style parent container and insert our element
+    // container.parentElement.style.minHeight = "unset";
+    // container.style.width = "300px";
+    // container.style.minHeight = "unset";
+
+    container.appendChild(element);
+    this.runUpdate();
+  }
+
+  async runUpdate() {
+    while (!this.#destroyed) {
+      const memory = window.performance.memory;
+      const usedMB = Math.round(memory.usedJSHeapSize / (1024 * 1024));
+      const totalMB = Math.round(memory.totalJSHeapSize / (1024 * 1024));
+      const limitMB = Math.round(memory.jsHeapSizeLimit / (1024 * 1024));
+
+      const element = this.#element;
+      element.querySelector("td[data-memory-used]").innerHTML = `${usedMB}MB`;
+      element.querySelector("td[data-memory-total]").innerHTML = `${totalMB}MB`;
+      element.querySelector("td[data-memory-limit]").innerHTML = `${limitMB}MB`;
+      element.querySelector("td[data-memory-usage]").innerHTML =
+        `${Math.round((memory.usedJSHeapSize / memory.jsHeapSizeLimit) * 100)}%`;
+
+      // sleep for a second
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // wait for next paint
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+  }
+
+  destroy() {
+    this.#element.parentElement?.remove(this.#element);
+    this.#destroyed = true;
+  }
+
+  renderHTML() {
+    return `
+      <table>
+        <tbody>
+          <tr>
+            <th scope="row">Used:</th>
+            <td data-memory-used></td>
+          </tr>
+          <tr>
+            <th scope="row">Total:</th>
+            <td data-memory-total></td>
+          </tr>
+          <tr>
+            <th scope="row">Limit:</th>
+            <td data-memory-limit></td>
+          </tr>
+          <tr>
+            <th scope="row">Usage:</th>
+            <td data-memory-usage></td>
+          </tr>
+        </tbody>
+      </table>
+    `;
+  }
+}
+
+export default MemoryMonitor;

--- a/packages/client/embedded_plugins/MemoryMonitor.js
+++ b/packages/client/embedded_plugins/MemoryMonitor.js
@@ -7,8 +7,8 @@ class MemoryMonitor {
   render(container) {
     const element = this.#element;
     element.insertAdjacentHTML("afterbegin", this.renderHTML());
-
     container.appendChild(element);
+
     this.runUpdate();
   }
 

--- a/packages/client/src/Backend/GameLogic/GameManager.ts
+++ b/packages/client/src/Backend/GameLogic/GameManager.ts
@@ -705,22 +705,6 @@ export class GameManager extends EventEmitter {
       }
     }, 10_000);
 
-    this.memoryMonitorInterval = setInterval(() => {
-      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-      const memory = (performance as any).memory;
-      const usedMB = Math.round(memory.usedJSHeapSize / (1024 * 1024));
-      const totalMB = Math.round(memory.totalJSHeapSize / (1024 * 1024));
-      const limitMB = Math.round(memory.jsHeapSizeLimit / (1024 * 1024));
-      console.log("-------------------------------------");
-      console.log("[memory] used: ", `${usedMB}MB`);
-      console.log("[memory] total: ", `${totalMB}MB`);
-      console.log("[memory] limit: ", `${limitMB}MB`);
-      console.log(
-        "[memory] usage: ",
-        `${Math.round((memory.usedJSHeapSize / memory.jsHeapSizeLimit) * 100)}%`,
-      );
-    }, 200);
-
     this.hashRate = 0;
 
     this.settingsSubscription = settingChanged$.subscribe(

--- a/packages/client/src/Backend/GameLogic/GameManager.ts
+++ b/packages/client/src/Backend/GameLogic/GameManager.ts
@@ -412,11 +412,6 @@ export class GameManager extends EventEmitter {
   // private blueZoneInterval: ReturnType<typeof setInterval>;
 
   /**
-   * Handle to an interval that periodically monitors memory usage.
-   */
-  private memoryMonitorInterval: ReturnType<typeof setInterval>;
-
-  /**
    * Manages the process of mining new space territory.
    */
   private minerManager?: MinerManager;
@@ -877,7 +872,6 @@ export class GameManager extends EventEmitter {
     this.contractsAPI.destroy();
     this.persistentChunkStore.destroy();
     clearInterval(this.playerInterval);
-    clearInterval(this.memoryMonitorInterval);
     // NOTE: event
     // clearInterval(this.diagnosticsInterval);
     // clearInterval(this.scoreboardInterval);

--- a/packages/client/src/Backend/Plugins/EmbeddedPluginLoader.ts
+++ b/packages/client/src/Backend/Plugins/EmbeddedPluginLoader.ts
@@ -1,4 +1,5 @@
 import type { PluginId } from "@df/types";
+import { startCase } from "@df/utils/string";
 
 /**
  * This interface represents an embedded plugin, which is stored in `embedded_plugins/`.
@@ -47,7 +48,8 @@ export async function getEmbeddedPlugins(
         const newFileName = cleanFilename(filename);
         return {
           id: newFileName as PluginId,
-          name: newFileName,
+          // Prettify name using startCase e.g. "MemoryMonitor" => "Memory Monitor".
+          name: startCase(newFileName),
           code,
         };
       }),


### PR DESCRIPTION
Instead of printing "memory info" via console.log to dev console every 200ms, which makes it difficult to:
1. Use the dev console for anything anything besides reading the memory info.
2. Use the dev console to read other debug statements.
3. Work interactively with the dev console.

We now have a plugin that we can run in game to see the memory usage like this 👇 
![Skjermbilde 2025-01-16 kl  12 13 08](https://github.com/user-attachments/assets/373f25b1-2623-44d8-b75f-3c7343bb5d81)
